### PR TITLE
Revise configuration construction

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -69,7 +69,7 @@ steps:
     commands:
       - export CARGO_HOME=/tmp/cargo
       - export CARGO_TARGET_DIR=/tmp/cargo-target
-      - cargo test --lib -- --nocapture
+      - cargo test -- --nocapture
 
   - name: crates.io
     image: ayravat/rust:1.53.0-docker

--- a/epp-client/Cargo.toml
+++ b/epp-client/Cargo.toml
@@ -13,11 +13,9 @@ repository = "https://github.com/masalachai/epp-client"
 epp-client-macros = "0.1" # { path = "../epp-client-macros" }
 bytes = "1"
 chrono = "0.4"
-confy = "0.4"
 futures = "0.3"
 env_logger = "0.9"
 log = "0.4"
-lazy_static = "1.4"
 quick-xml = { version = "0.22", features = [ "serialize" ] }
 rustls = "0.20"
 rustls-pemfile = "0.2"

--- a/epp-client/src/config.rs
+++ b/epp-client/src/config.rs
@@ -47,23 +47,12 @@
 //! let tls = registry.tls_files().unwrap();
 //! ```
 
-use confy;
-use lazy_static::lazy_static;
 use rustls::{Certificate, PrivateKey};
 use rustls_pemfile;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::default;
 use std::io::{Seek, SeekFrom};
 use std::{fs, io};
-
-lazy_static! {
-    /// Static reference to the config file
-    pub static ref CONFIG: EppClientConfig = match confy::load("epp-client") {
-        Ok(cfg) => cfg,
-        Err(e) => panic!("Config read error: {}", e),
-    };
-}
 
 /// Paths to the client certificate and client key PEM files
 #[derive(Serialize, Deserialize, Debug)]
@@ -75,39 +64,18 @@ pub struct EppClientTlsFiles {
 /// Connection details to connect to and authenticate with a registry
 #[derive(Serialize, Deserialize, Debug)]
 pub struct EppClientConnection {
-    host: String,
-    port: u16,
-    username: String,
-    password: String,
-    ext_uris: Option<Vec<String>>,
-    tls_files: Option<EppClientTlsFiles>,
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub password: String,
+    pub ext_uris: Option<Vec<String>>,
+    pub tls_files: Option<EppClientTlsFiles>,
 }
 
 /// Config that stores settings for multiple registries
 #[derive(Serialize, Deserialize, Debug)]
 pub struct EppClientConfig {
     pub registry: HashMap<String, EppClientConnection>,
-}
-
-impl default::Default for EppClientConfig {
-    fn default() -> Self {
-        let mut registries: HashMap<String, EppClientConnection> = HashMap::new();
-        let registrar = EppClientConnection {
-            host: "epphost".to_string(),
-            port: 700,
-            username: "username".to_string(),
-            password: "password".to_string(),
-            ext_uris: Some(vec![]),
-            tls_files: Some(EppClientTlsFiles {
-                cert_chain: "/path/to/certificate/chain/pemfile".to_string(),
-                key: "/path/to/private/key/pemfile".to_string(),
-            }),
-        };
-        registries.insert("verisign".to_string(), registrar);
-        Self {
-            registry: registries,
-        }
-    }
 }
 
 impl EppClientConnection {

--- a/epp-client/src/config.rs
+++ b/epp-client/src/config.rs
@@ -1,38 +1,31 @@
-//! Config load module
+//! Config
 //!
-//! Loads the configuration and credentials for each registry connection from
-//! the `$XDG_CONFIG_HOME/epp-client/epp-client.toml` file
-//!
-//! ## Usage
-//!
-//! The config is automatically loaded when the module is initialized
-//! and is available through the `epp_client::config::CONFIG` variable
-//!
-//! ## Sample config
-//!
-//! ```toml
-//! [registry.verisign]
-//! host = 'epp.verisign-grs.com'
-//! port = 700
-//! username = 'username'
-//! password = 'password'
-//! # service extensions
-//! ext_uris = []
-//!
-//! [registry.hexonet.tls_files]
-//! # the full client certificate chain in PEM format
-//! cert_chain = '/path/to/certificate/chain/pemfile'
-//! # the RSA private key for your certificate
-//! key = '/path/to/private/key/pemfile'
-//! ```
+//! This module contains the connection configuration for the EPP client.
 //!
 //! ## Example
 //!
-//! ```rust
-//! use epp_client::config::CONFIG;
+//! ```no_run
+//! use std::collections::HashMap;
+//!
+//! use epp_client::config::{EppClientConfig, EppClientConnection};
+//!
+//! // Create a config
+//! let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+//! registry.insert(
+//!     "registry_name".to_owned(),
+//!     EppClientConnection {
+//!         host: "example.com".to_owned(),
+//!         port: 700,
+//!         username: "username".to_owned(),
+//!         password: "password".to_owned(),
+//!         ext_uris: None,
+//!         tls_files: None,
+//!     },
+//! );
+//! let config = EppClientConfig { registry };
 //!
 //! // Get configuration for the relevant registry section
-//! let registry = CONFIG.registry("verisign").unwrap();
+//! let registry = config.registry("verisign").unwrap();
 //!
 //! // Get EPP host name and port no.
 //! let remote = registry.connection_details();

--- a/epp-client/src/connection/client.rs
+++ b/epp-client/src/connection/client.rs
@@ -2,28 +2,47 @@
 //!
 //! ## Example
 //!
-//! ```rust
+//! ```no_run
+//! use std::collections::HashMap;
+//!
+//! use epp_client::config::{EppClientConfig, EppClientConnection};
 //! use epp_client::EppClient;
 //! use epp_client::epp::{EppDomainCheck, EppDomainCheckResponse};
 //! use epp_client::epp::generate_client_tr_id;
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     // Create an instance of EppClient, specifying the name of the registry as in
-//!     // the config file
-//!     let mut client = match EppClient::new("verisign").await {
-//!         Ok(client) => client,
-//!         Err(e) => panic!("Failed to create EppClient: {}",  e)
-//!     };
 //!
-//!     // Make a EPP Hello call to the registry
-//!     let greeting = client.hello().await.unwrap();
-//!     println!("{:?}", greeting);
+//! // Create a config
+//! let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+//! registry.insert(
+//!     "registry_name".to_owned(),
+//!     EppClientConnection {
+//!         host: "example.com".to_owned(),
+//!         port: 700,
+//!         username: "username".to_owned(),
+//!         password: "password".to_owned(),
+//!         ext_uris: None,
+//!         tls_files: None,
+//!     },
+//! );
+//! let config = EppClientConfig { registry };
 //!
-//!     // Execute an EPP Command against the registry with distinct request and response objects
-//!     let domain_check = EppDomainCheck::new(vec!["eppdev.com", "eppdev.net"], generate_client_tr_id(&client).as_str());
-//!     let response = client.transact::<_, EppDomainCheckResponse>(&domain_check).await.unwrap();
-//!     println!("{:?}", response);
+//! // Create an instance of EppClient, passing the config and the registry you want to connect to
+//! let mut client = match EppClient::new(&config, "registry_name").await {
+//!     Ok(client) => client,
+//!     Err(e) => panic!("Failed to create EppClient: {}",  e)
+//! };
+//!
+//! // Make a EPP Hello call to the registry
+//! let greeting = client.hello().await.unwrap();
+//! println!("{:?}", greeting);
+//!
+//! // Execute an EPP Command against the registry with distinct request and response objects
+//! let domain_check = EppDomainCheck::new(vec!["eppdev.com", "eppdev.net"], generate_client_tr_id(&client).as_str());
+//! let response = client.transact::<_, EppDomainCheckResponse>(&domain_check).await.unwrap();
+//! println!("{:?}", response);
+//!
 //! }
 //! ```
 

--- a/epp-client/src/epp/request/contact/check.rs
+++ b/epp-client/src/epp/request/contact/check.rs
@@ -1,5 +1,4 @@
-//! Types for EPP contact check request
-
+/// Types for EPP contact check request
 use epp_client_macros::*;
 
 use crate::epp::object::{ElementName, EppObject, StringValue, StringValueTrait};
@@ -11,16 +10,33 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```rust
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppContactCheck, EppContactCheckResponse};
 /// use epp_client::epp::generate_client_tr_id;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/contact/create.rs
+++ b/epp-client/src/epp/request/contact/create.rs
@@ -12,7 +12,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::object::data::{Address, Phone, PostalInfo};
 /// use epp_client::epp::{EppContactCreate, EppContactCreateResponse};
@@ -20,9 +23,23 @@ use serde::{Deserialize, Serialize};
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/contact/delete.rs
+++ b/epp-client/src/epp/request/contact/delete.rs
@@ -11,16 +11,33 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppContactDelete, EppContactDeleteResponse};
 /// use epp_client::epp::generate_client_tr_id;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/contact/info.rs
+++ b/epp-client/src/epp/request/contact/info.rs
@@ -12,16 +12,33 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppContactInfo, EppContactInfoResponse};
 /// use epp_client::epp::generate_client_tr_id;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/contact/update.rs
+++ b/epp-client/src/epp/request/contact/update.rs
@@ -14,16 +14,34 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppContactUpdate, EppContactUpdateResponse};
 /// use epp_client::epp::generate_client_tr_id;
+/// use epp_client::epp::object::data::ContactStatus;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/domain/check.rs
+++ b/epp-client/src/epp/request/domain/check.rs
@@ -11,16 +11,33 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```rust
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppDomainCheck, EppDomainCheckResponse};
 /// use epp_client::epp::generate_client_tr_id;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/domain/create.rs
+++ b/epp-client/src/epp/request/domain/create.rs
@@ -15,7 +15,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::object::data::DomainContact;
 /// use epp_client::epp::{EppDomainCreate, EppDomainCreateResponse};
@@ -23,9 +26,23 @@ use serde::{Deserialize, Serialize};
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/domain/delete.rs
+++ b/epp-client/src/epp/request/domain/delete.rs
@@ -11,16 +11,33 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppDomainDelete, EppDomainDeleteResponse};
 /// use epp_client::epp::generate_client_tr_id;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/domain/info.rs
+++ b/epp-client/src/epp/request/domain/info.rs
@@ -11,16 +11,33 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppDomainInfo, EppDomainInfoResponse};
 /// use epp_client::epp::generate_client_tr_id;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/domain/renew.rs
+++ b/epp-client/src/epp/request/domain/renew.rs
@@ -13,17 +13,35 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
 /// use chrono::NaiveDate;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppDomainRenew, EppDomainRenewResponse};
 /// use epp_client::epp::generate_client_tr_id;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/domain/rgp/report.rs
+++ b/epp-client/src/epp/request/domain/rgp/report.rs
@@ -16,7 +16,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppDomainRgpRestoreReport, EppDomainRgpRestoreReportResponse};
 /// use epp_client::epp::generate_client_tr_id;
@@ -25,9 +28,23 @@ use serde::{Deserialize, Serialize};
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/domain/rgp/request.rs
+++ b/epp-client/src/epp/request/domain/rgp/request.rs
@@ -15,16 +15,33 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppDomainRgpRestoreRequest, EppDomainRgpRestoreRequestResponse};
 /// use epp_client::epp::generate_client_tr_id;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/domain/transfer.rs
+++ b/epp-client/src/epp/request/domain/transfer.rs
@@ -12,16 +12,33 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppDomainTransferRequest, EppDomainTransferRequestResponse};
 /// use epp_client::epp::generate_client_tr_id;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
@@ -43,16 +60,33 @@ pub type EppDomainTransferRequest = EppObject<Command<DomainTransfer>>;
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppDomainTransferApprove, EppDomainTransferApproveResponse};
 /// use epp_client::epp::generate_client_tr_id;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
@@ -74,16 +108,33 @@ pub type EppDomainTransferApprove = EppObject<Command<DomainTransfer>>;
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppDomainTransferReject, EppDomainTransferRejectResponse};
 /// use epp_client::epp::generate_client_tr_id;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
@@ -105,16 +156,33 @@ pub type EppDomainTransferReject = EppObject<Command<DomainTransfer>>;
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppDomainTransferCancel, EppDomainTransferCancelResponse};
 /// use epp_client::epp::generate_client_tr_id;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
@@ -136,16 +204,33 @@ pub type EppDomainTransferCancel = EppObject<Command<DomainTransfer>>;
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppDomainTransferQuery, EppDomainTransferQueryResponse};
 /// use epp_client::epp::generate_client_tr_id;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/domain/update.rs
+++ b/epp-client/src/epp/request/domain/update.rs
@@ -13,7 +13,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::object::data::{DomainStatus, DomainContact};
 /// use epp_client::epp::{EppDomainUpdate, EppDomainUpdateResponse, DomainAddRemove};
@@ -21,9 +24,23 @@ use serde::{Deserialize, Serialize};
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/host/check.rs
+++ b/epp-client/src/epp/request/host/check.rs
@@ -11,16 +11,33 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```rust
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppHostCheck, EppHostCheckResponse};
 /// use epp_client::epp::generate_client_tr_id;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/host/create.rs
+++ b/epp-client/src/epp/request/host/create.rs
@@ -12,7 +12,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::object::data::HostAddr;
 /// use epp_client::epp::{EppHostCreate, EppHostCreateResponse};
@@ -20,9 +23,23 @@ use serde::{Deserialize, Serialize};
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/host/delete.rs
+++ b/epp-client/src/epp/request/host/delete.rs
@@ -11,16 +11,33 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppHostDelete, EppHostDeleteResponse};
 /// use epp_client::epp::generate_client_tr_id;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/host/info.rs
+++ b/epp-client/src/epp/request/host/info.rs
@@ -11,16 +11,33 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppHostInfo, EppHostInfoResponse};
 /// use epp_client::epp::generate_client_tr_id;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/host/update.rs
+++ b/epp-client/src/epp/request/host/update.rs
@@ -12,7 +12,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::object::StringValueTrait;
 /// use epp_client::epp::object::data::{HostAddr, HostStatus};
@@ -21,9 +24,23 @@ use serde::{Deserialize, Serialize};
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/message/ack.rs
+++ b/epp-client/src/epp/request/message/ack.rs
@@ -9,16 +9,33 @@ use serde::{Deserialize, Serialize};
 /// Type that represents the &lt;epp&gt; request for registry <poll op="ack"> command
 /// ## Usage
 ///
-/// ```ignore
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppMessageAck, EppMessageAckResponse};
 /// use epp_client::epp::generate_client_tr_id;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/epp/request/message/poll.rs
+++ b/epp-client/src/epp/request/message/poll.rs
@@ -10,16 +10,33 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Usage
 ///
-/// ```rust
+/// ```no_run
+/// use std::collections::HashMap;
+///
+/// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
 /// use epp_client::epp::{EppMessagePoll, EppMessagePollResponse};
 /// use epp_client::epp::generate_client_tr_id;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // Create an instance of EppClient, specifying the name of the registry as in
-///     // the config file
-///     let mut client = match EppClient::new("verisign").await {
+///     // Create a config
+///     let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+///     registry.insert(
+///         "registry_name".to_owned(),
+///         EppClientConnection {
+///             host: "example.com".to_owned(),
+///             port: 700,
+///             username: "username".to_owned(),
+///             password: "password".to_owned(),
+///             ext_uris: None,
+///             tls_files: None,
+///         },
+///     );
+///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };

--- a/epp-client/src/lib.rs
+++ b/epp-client/src/lib.rs
@@ -33,68 +33,63 @@
 //! - RGP Restore Request - [`EppDomainRgpRestoreRequest`](epp/request/domain/rgp/request/type.EppDomainRgpRestoreRequest.html)
 //! - RGP Restore Report - [`EppDomainRgpRestoreReport`](epp/request/domain/rgp/report/type.EppDomainRgpRestoreReport.html)
 //!
-//! ## Prerequisites
-//!
-//! To use the library, you must have an `epp-client/epp-client.toml` config file with the relevant registry
-//! credentials in your default user configuration directory on your OS. For Linux, this is the `XDG user directory`,
-//! usually located at `$HOME/.config` or defined by the `XDG_CONFIG_HOME` environment variable.
-//!
-//! An example config looks like this:
-//!
-//! ```toml
-//! [registry.verisign]
-//! host = 'epp.verisign-grs.com'
-//! port = 700
-//! username = 'username'
-//! password = 'password'
-//! # service extensions
-//! ext_uris = []
-//!
-//! [registry.verisign.tls_files]
-//! # the full client certificate chain in PEM format
-//! cert_chain = '/path/to/certificate/chain/pemfile'
-//! # the RSA private key for your certificate
-//! key = '/path/to/private/key/pemfile'
-//! ```
-//!
 //! ## Operation
 //!
 //! Once the config is set correctly, you can create a mut variable of type [`EppClient`] to transact
 //! with the domain registry
 //!
-//! ```rust
+//! ```no_run
+//! use std::collections::HashMap;
+//!
+//! use epp_client::config::{EppClientConfig, EppClientConnection};
 //! use epp_client::EppClient;
 //! use epp_client::epp::{EppDomainCheck, EppDomainCheckResponse};
 //! use epp_client::epp::generate_client_tr_id;
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     // Create an instance of EppClient, specifying the name of the registry as in
-//!     // the config file
-//!     let mut client = match EppClient::new("verisign").await {
-//!         Ok(client) => client,
-//!         Err(e) => panic!("Failed to create EppClient: {}",  e)
-//!     };
 //!
-//!     // Make a domain check call, which returns an object of type EppDomainCheckResponse
-//!     // that contains the result of the call
-//!     let domain_check = EppDomainCheck::new(
-//!         vec!["eppdev.com", "eppdev.net"],
-//!         generate_client_tr_id(&client).as_str()
-//!     );
+//! // Create a config
+//! let mut registry: HashMap<String, EppClientConnection> = HashMap::new();
+//! registry.insert(
+//!     "registry_name".to_owned(),
+//!     EppClientConnection {
+//!         host: "example.com".to_owned(),
+//!         port: 700,
+//!         username: "username".to_owned(),
+//!         password: "password".to_owned(),
+//!         ext_uris: None,
+//!         tls_files: None,
+//!     },
+//! );
+//! let config = EppClientConfig { registry };
 //!
-//!     let response = client.transact::<_, EppDomainCheckResponse>(&domain_check).await.unwrap();
+//! // Create an instance of EppClient, passing the config and the registry you want to connect to
+//! let mut client = match EppClient::new(&config, "registry_name").await {
+//!     Ok(client) => client,
+//!     Err(e) => panic!("Failed to create EppClient: {}",  e)
+//! };
 //!
-//!     // print the availability results
-//!     response.data.res_data.unwrap().check_data.domain_list
-//!         .iter()
-//!         .for_each(|chk| println!("Domain: {}, Available: {}", chk.domain.name, chk.domain.available));
+//! // Make a domain check call, which returns an object of type EppDomainCheckResponse
+//! // that contains the result of the call
+//! let domain_check = EppDomainCheck::new(
+//!     vec!["eppdev.com", "eppdev.net"],
+//!     generate_client_tr_id(&client).as_str()
+//! );
+//!
+//! let response = client.transact::<_, EppDomainCheckResponse>(&domain_check).await.unwrap();
+//!
+//! // print the availability results
+//! response.data.res_data.unwrap().check_data.domain_list
+//!     .iter()
+//!     .for_each(|chk| println!("Domain: {}, Available: {}", chk.domain.name, chk.domain.available));
+//!
 //! }
 //! ```
 //!
 //! The output would look similar to the following
 //!
-//! ```
+//! ```text
 //! Domain: eppdev.com, Available: 1
 //! Domain: eppdev.net, Available: 1
 //! ```


### PR DESCRIPTION
Closes #1 

This change removes `confy` completely. I gave some rationale for that in #1. This also removes the need for a default implementation for `EppClientConfig ` this seemed awkward to me since it should be impossible to create a client without a config.

Instead of using `lazy_static`, the config is instantiated and passed from the caller.

Finally, I removed the use of `mpsc` in `connect` since I think the didn't provide much benefit since connect is only called once per client.