### PR TITLE
Apply code formatting and clean up clippy recommendations

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,54 @@ platform:
   arch: amd64
 
 steps:
+  - name: check
+    image: ayravat/rust:1.53.0-ci
+    volumes:
+      - name: ssh
+        path: /root/.ssh
+      - name: target
+        path: /tmp/cargo-target
+      - name: cache
+        path: /tmp/cargo
+      - name: config
+        path: /root/.config/epp-client
+    commands:
+      - export CARGO_HOME=/tmp/cargo
+      - export CARGO_TARGET_DIR=/tmp/cargo-target
+      - cargo check --all-targets
+
+  - name: fmt
+    image: ayravat/rust:1.53.0-ci
+    volumes:
+      - name: ssh
+        path: /root/.ssh
+      - name: target
+        path: /tmp/cargo-target
+      - name: cache
+        path: /tmp/cargo
+      - name: config
+        path: /root/.config/epp-client
+    commands:
+      - export CARGO_HOME=/tmp/cargo
+      - export CARGO_TARGET_DIR=/tmp/cargo-target
+      - cargo fmt --all -- --check
+
+  - name: clippy
+    image: ayravat/rust:1.53.0-ci
+    volumes:
+      - name: ssh
+        path: /root/.ssh
+      - name: target
+        path: /tmp/cargo-target
+      - name: cache
+        path: /tmp/cargo
+      - name: config
+        path: /root/.config/epp-client
+    commands:
+      - export CARGO_HOME=/tmp/cargo
+      - export CARGO_TARGET_DIR=/tmp/cargo-target
+      - cargo clippy --workspace --all-targets -- -D warnings
+
   - name: test
     image: ayravat/rust:1.53.0-ci
     volumes:

--- a/epp-client-macros/src/lib.rs
+++ b/epp-client-macros/src/lib.rs
@@ -17,11 +17,11 @@ fn element_name_macro(ast: &syn::DeriveInput) -> TokenStream {
     let mut elem_name = ast.ident.to_string();
     let (impl_generics, type_generics, _) = &ast.generics.split_for_impl();
 
-    if ast.attrs.len() > 0 {
+    if !ast.attrs.is_empty() {
         let attribute = &ast.attrs[0];
         match attribute.parse_meta() {
             Ok(syn::Meta::List(meta)) => {
-                if meta.nested.len() > 0 {
+                if !meta.nested.is_empty() {
                     elem_name = match &meta.nested[0] {
                         syn::NestedMeta::Meta(syn::Meta::NameValue(v)) => match &v.lit {
                             syn::Lit::Str(lit) => lit.value(),

--- a/epp-client/src/config.rs
+++ b/epp-client/src/config.rs
@@ -137,23 +137,27 @@ impl EppClientConnection {
     }
     /// Parses the client certificate chain
     fn client_certificate(&self) -> Option<Vec<Certificate>> {
-        self.tls_files.as_ref().map(|tls| rustls_pemfile::certs(&mut io::BufReader::new(
-                    fs::File::open(tls.cert_chain.to_string()).unwrap(),
-                ))
-                .unwrap()
-                .iter()
-                .map(|v| Certificate(v.clone()))
-                .collect())
+        self.tls_files.as_ref().map(|tls| {
+            rustls_pemfile::certs(&mut io::BufReader::new(
+                fs::File::open(tls.cert_chain.to_string()).unwrap(),
+            ))
+            .unwrap()
+            .iter()
+            .map(|v| Certificate(v.clone()))
+            .collect()
+        })
     }
     /// Parses the client RSA private key
     fn key(&self) -> Option<PrivateKey> {
-        self.tls_files.as_ref().map(|tls| rustls::PrivateKey(
+        self.tls_files.as_ref().map(|tls| {
+            rustls::PrivateKey(
                 rustls_pemfile::rsa_private_keys(&mut io::BufReader::new(
                     fs::File::open(tls.key.to_string()).unwrap(),
                 ))
                 .unwrap()[0]
                     .clone(),
-            ))
+            )
+        })
     }
 }
 

--- a/epp-client/src/config.rs
+++ b/epp-client/src/config.rs
@@ -31,22 +31,20 @@
 //! ```rust
 //! use epp_client::config::CONFIG;
 //!
-//! fn main() {
-//!     // Get configuration for the relevant registry section
-//!     let registry = CONFIG.registry("verisign").unwrap();
+//! // Get configuration for the relevant registry section
+//! let registry = CONFIG.registry("verisign").unwrap();
 //!
-//!     // Get EPP host name and port no.
-//!     let remote = registry.connection_details();
+//! // Get EPP host name and port no.
+//! let remote = registry.connection_details();
 //!
-//!     // Get username and password
-//!     let credentials = registry.credentials();
+//! // Get username and password
+//! let credentials = registry.credentials();
 //!
-//!     // Get EPP service extensions
-//!     let service_extensions = registry.ext_uris().unwrap();
+//! // Get EPP service extensions
+//! let service_extensions = registry.ext_uris().unwrap();
 //!
-//!     // Get client certificate and private key
-//!     let tls = registry.tls_files().unwrap();
-//! }
+//! // Get client certificate and private key
+//! let tls = registry.tls_files().unwrap();
 //! ```
 
 use confy;

--- a/epp-client/src/config.rs
+++ b/epp-client/src/config.rs
@@ -137,31 +137,23 @@ impl EppClientConnection {
     }
     /// Parses the client certificate chain
     fn client_certificate(&self) -> Option<Vec<Certificate>> {
-        match &self.tls_files {
-            Some(tls) => Some(
-                rustls_pemfile::certs(&mut io::BufReader::new(
+        self.tls_files.as_ref().map(|tls| rustls_pemfile::certs(&mut io::BufReader::new(
                     fs::File::open(tls.cert_chain.to_string()).unwrap(),
                 ))
                 .unwrap()
                 .iter()
                 .map(|v| Certificate(v.clone()))
-                .collect(),
-            ),
-            None => None,
-        }
+                .collect())
     }
     /// Parses the client RSA private key
     fn key(&self) -> Option<PrivateKey> {
-        match &self.tls_files {
-            Some(tls) => Some(rustls::PrivateKey(
+        self.tls_files.as_ref().map(|tls| rustls::PrivateKey(
                 rustls_pemfile::rsa_private_keys(&mut io::BufReader::new(
                     fs::File::open(tls.key.to_string()).unwrap(),
                 ))
                 .unwrap()[0]
                     .clone(),
-            )),
-            None => None,
-        }
+            ))
     }
 }
 

--- a/epp-client/src/connection.rs
+++ b/epp-client/src/connection.rs
@@ -1,5 +1,5 @@
 //! Manages registry connections and reading/writing to them
 //! and connects the EppClient instances to them
 
-pub mod registry;
 pub mod client;
+pub mod registry;

--- a/epp-client/src/connection/client.rs
+++ b/epp-client/src/connection/client.rs
@@ -198,6 +198,6 @@ impl EppClient {
 
 impl Drop for EppClient {
     fn drop(&mut self) {
-        block_on(self.logout());
+        let _ = block_on(self.logout());
     }
 }

--- a/epp-client/src/connection/registry.rs
+++ b/epp-client/src/connection/registry.rs
@@ -38,9 +38,9 @@ impl EppConnection {
         debug!("{}: greeting: {}", registry, greeting);
 
         Ok(EppConnection {
-            registry: registry,
-            stream: stream,
-            greeting: greeting
+            registry,
+            stream,
+            greeting
         })
     }
 
@@ -64,7 +64,7 @@ impl EppConnection {
         let len_u32: [u8; 4] = u32::to_be_bytes(len.try_into()?);
 
         buf[..4].clone_from_slice(&len_u32);
-        buf[4..].clone_from_slice(&content.as_bytes());
+        buf[4..].clone_from_slice(content.as_bytes());
 
         self.write(&buf).await
     }
@@ -89,7 +89,7 @@ impl EppConnection {
             debug!("{}: Read: {} bytes", self.registry, read);
             buf.extend_from_slice(&read_buf[0..read]);
 
-            read_size = read_size + read;
+            read_size += read;
             debug!("{}: Total read: {} bytes", self.registry, read_size);
 
             if read == 0 {
@@ -117,7 +117,7 @@ impl EppConnection {
     /// receieved to the request
     pub async fn transact(&mut self, content: &str) -> Result<String, Box<dyn Error>> {
         debug!("{}: request: {}", self.registry, content);
-        self.send_epp_request(&content).await?;
+        self.send_epp_request(content).await?;
 
         let response = self.get_epp_response().await?;
         debug!("{}: response: {}", self.registry, response);
@@ -149,8 +149,7 @@ pub async fn epp_connect(registry_creds: &EppClientConnection) -> Result<Connect
 
     let addr = (host.as_str(), port)
         .to_socket_addrs()?
-        .next()
-        .ok_or_else(|| stdio::ErrorKind::NotFound)?;
+        .next().ok_or(stdio::ErrorKind::NotFound)?;
 
     let mut roots = RootCertStore::empty();
     roots.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
@@ -184,7 +183,7 @@ pub async fn epp_connect(registry_creds: &EppClientConnection) -> Result<Connect
     let (reader, writer) = split(stream);
 
     Ok(ConnectionStream {
-        reader: reader,
-        writer: writer,
+        reader,
+        writer,
     })
 }

--- a/epp-client/src/connection/registry.rs
+++ b/epp-client/src/connection/registry.rs
@@ -48,7 +48,7 @@ impl EppConnection {
     }
 
     /// Writes to the socket
-    async fn write(&mut self, buf: &Vec<u8>) -> Result<(), Box<dyn Error>> {
+    async fn write(&mut self, buf: &[u8]) -> Result<(), Box<dyn Error>> {
         let wrote = self.stream.writer.write(buf).await?;
 
         debug!("{}: Wrote {} bytes", self.registry, wrote);
@@ -139,7 +139,7 @@ impl EppConnection {
 
 impl Drop for EppConnection {
     fn drop(&mut self) {
-        block_on(self.close());
+        let _ = block_on(self.close());
     }
 }
 

--- a/epp-client/src/connection/registry.rs
+++ b/epp-client/src/connection/registry.rs
@@ -1,16 +1,18 @@
 //! Manages registry connections and reading/writing to them
 
-use std::sync::Arc;
-use std::{str, u32};
 use bytes::BytesMut;
-use std::convert::TryInto;
 use futures::executor::block_on;
-use std::{error::Error, net::ToSocketAddrs, io as stdio};
-use tokio_rustls::{TlsConnector, rustls::ClientConfig, client::TlsStream};
-use tokio::{net::TcpStream, io::AsyncWriteExt, io::AsyncReadExt, io::split, io::ReadHalf, io::WriteHalf};
-use rustls::{RootCertStore, OwnedTrustAnchor};
+use rustls::{OwnedTrustAnchor, RootCertStore};
+use std::convert::TryInto;
+use std::sync::Arc;
+use std::{error::Error, io as stdio, net::ToSocketAddrs};
+use std::{str, u32};
+use tokio::{
+    io::split, io::AsyncReadExt, io::AsyncWriteExt, io::ReadHalf, io::WriteHalf, net::TcpStream,
+};
+use tokio_rustls::{client::TlsStream, rustls::ClientConfig, TlsConnector};
 
-use crate::config::{EppClientConnection};
+use crate::config::EppClientConnection;
 use crate::error;
 
 /// Socket stream for the connection to the registry
@@ -30,7 +32,8 @@ impl EppConnection {
     /// Create an EppConnection instance with the stream to the registry
     pub async fn new(
         registry: String,
-        mut stream: ConnectionStream) -> Result<EppConnection, Box<dyn Error>> {
+        mut stream: ConnectionStream,
+    ) -> Result<EppConnection, Box<dyn Error>> {
         let mut buf = vec![0u8; 4096];
         stream.reader.read(&mut buf).await?;
         let greeting = str::from_utf8(&buf[4..])?.to_string();
@@ -40,7 +43,7 @@ impl EppConnection {
         Ok(EppConnection {
             registry,
             stream,
-            greeting
+            greeting,
         })
     }
 
@@ -74,7 +77,7 @@ impl EppConnection {
         let mut buf = [0u8; 4];
         self.stream.reader.read_exact(&mut buf).await?;
 
-        let buf_size :usize = u32::from_be_bytes(buf).try_into()?;
+        let buf_size: usize = u32::from_be_bytes(buf).try_into()?;
 
         let message_size = buf_size - 4;
         debug!("{}: Response buffer size: {}", self.registry, message_size);
@@ -82,7 +85,7 @@ impl EppConnection {
         let mut buf = BytesMut::with_capacity(4096);
         let mut read_buf = vec![0u8; 4096];
 
-        let mut read_size :usize = 0;
+        let mut read_size: usize = 0;
 
         loop {
             let read = self.stream.reader.read(&mut read_buf).await?;
@@ -142,14 +145,17 @@ impl Drop for EppConnection {
 
 /// Establishes a TLS connection to a registry and returns a ConnectionStream instance containing the
 /// socket stream to read/write to the connection
-pub async fn epp_connect(registry_creds: &EppClientConnection) -> Result<ConnectionStream, error::Error> {
+pub async fn epp_connect(
+    registry_creds: &EppClientConnection,
+) -> Result<ConnectionStream, error::Error> {
     let (host, port) = registry_creds.connection_details();
 
     info!("Connecting: EPP Server: {} Port: {}", host, port);
 
     let addr = (host.as_str(), port)
         .to_socket_addrs()?
-        .next().ok_or(stdio::ErrorKind::NotFound)?;
+        .next()
+        .ok_or(stdio::ErrorKind::NotFound)?;
 
     let mut roots = RootCertStore::empty();
     roots.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
@@ -168,22 +174,23 @@ pub async fn epp_connect(registry_creds: &EppClientConnection) -> Result<Connect
         Some((cert_chain, key)) => match builder.with_single_cert(cert_chain, key) {
             Ok(config) => config,
             Err(e) => return Err(format!("Failed to set client TLS credentials: {}", e).into()),
-        }
+        },
         None => builder.with_no_client_auth(),
     };
 
     let connector = TlsConnector::from(Arc::new(config));
     let stream = TcpStream::connect(&addr).await?;
 
-    let domain = host.as_str().try_into()
-        .map_err(|_| stdio::Error::new(stdio::ErrorKind::InvalidInput, format!("Invalid domain: {}", host)))?;
+    let domain = host.as_str().try_into().map_err(|_| {
+        stdio::Error::new(
+            stdio::ErrorKind::InvalidInput,
+            format!("Invalid domain: {}", host),
+        )
+    })?;
 
     let stream = connector.connect(domain, stream).await?;
 
     let (reader, writer) = split(stream);
 
-    Ok(ConnectionStream {
-        reader,
-        writer,
-    })
+    Ok(ConnectionStream { reader, writer })
 }

--- a/epp-client/src/epp/object.rs
+++ b/epp-client/src/epp/object.rs
@@ -156,7 +156,7 @@ impl<T: ElementName> EppObject<T> {
     pub fn build(data: T) -> EppObject<T> {
         EppObject {
             // xml: None,
-            data: data,
+            data,
             xmlns: EPP_XMLNS.to_string(),
             xmlns_xsi: EPP_XMLNS_XSI.to_string(),
             xsi_schema_location: EPP_XSI_SCHEMA_LOCATION.to_string(),

--- a/epp-client/src/epp/object/data.rs
+++ b/epp-client/src/epp/object/data.rs
@@ -106,7 +106,7 @@ impl Period {
     pub fn new(length: u16) -> Period {
         Period {
             unit: "y".to_string(),
-            length: length,
+            length,
         }
     }
 
@@ -216,7 +216,7 @@ impl Address {
             .collect::<Vec<StringValue>>();
 
         Address {
-            street: street,
+            street,
             city: city.to_string_value(),
             province: province.to_string_value(),
             postal_code: postal_code.to_string_value(),
@@ -232,7 +232,7 @@ impl PostalInfo {
             info_type: info_type.to_string(),
             name: name.to_string_value(),
             organization: organization.to_string_value(),
-            address: address,
+            address,
         }
     }
 }

--- a/epp-client/src/epp/object/data.rs
+++ b/epp-client/src/epp/object/data.rs
@@ -212,7 +212,7 @@ impl Address {
     ) -> Address {
         let street = street
             .iter()
-            .filter_map(|s| Some(s.to_string_value()))
+            .map(|s| s.to_string_value())
             .collect::<Vec<StringValue>>();
 
         Address {

--- a/epp-client/src/epp/request.rs
+++ b/epp-client/src/epp/request.rs
@@ -97,6 +97,12 @@ impl EppHello {
     }
 }
 
+impl Default for EppHello {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, ElementName)]
 #[element_name(name = "login")]
 /// Type corresponding to the &lt;login&gt; tag in an EPP XML login request

--- a/epp-client/src/epp/request.rs
+++ b/epp-client/src/epp/request.rs
@@ -122,9 +122,11 @@ impl EppLogin {
         ext_uris: &Option<Vec<String>>,
         client_tr_id: &str,
     ) -> EppLogin {
-        let ext_uris = ext_uris.as_ref().map(|uris| uris.iter()
-                    .map(|u| u.to_string_value())
-                    .collect::<Vec<StringValue>>());
+        let ext_uris = ext_uris.as_ref().map(|uris| {
+            uris.iter()
+                .map(|u| u.to_string_value())
+                .collect::<Vec<StringValue>>()
+        });
 
         let login = Login {
             username: username.to_string_value(),

--- a/epp-client/src/epp/request.rs
+++ b/epp-client/src/epp/request.rs
@@ -61,7 +61,7 @@ impl<T: ElementName> Command<T> {
     /// Creates a new &lt;command&gt; tag for an EPP document
     pub fn new(command: T, client_tr_id: &str) -> Command<T> {
         Command {
-            command: command,
+            command,
             extension: None,
             client_tr_id: client_tr_id.to_string_value(),
         }
@@ -72,7 +72,7 @@ impl<T: ElementName, E: ElementName> CommandWithExtension<T, E> {
     /// Creates a new &lt;command&gt; tag for an EPP document with a containing &lt;extension&gt; tag
     pub fn build(command: T, ext: E, client_tr_id: &str) -> CommandWithExtension<T, E> {
         CommandWithExtension {
-            command: command,
+            command,
             extension: Some(Extension { data: ext }),
             client_tr_id: client_tr_id.to_string_value(),
         }
@@ -122,14 +122,9 @@ impl EppLogin {
         ext_uris: &Option<Vec<String>>,
         client_tr_id: &str,
     ) -> EppLogin {
-        let ext_uris = match ext_uris {
-            Some(uris) => Some(
-                uris.iter()
+        let ext_uris = ext_uris.as_ref().map(|uris| uris.iter()
                     .map(|u| u.to_string_value())
-                    .collect::<Vec<StringValue>>(),
-            ),
-            None => None,
-        };
+                    .collect::<Vec<StringValue>>());
 
         let login = Login {
             username: username.to_string_value(),
@@ -144,7 +139,7 @@ impl EppLogin {
                     EPP_CONTACT_XMLNS.to_string_value(),
                     EPP_DOMAIN_XMLNS.to_string_value(),
                 ],
-                svc_ext: Some(ServiceExtension { ext_uris: ext_uris }),
+                svc_ext: Some(ServiceExtension { ext_uris }),
             },
         };
 

--- a/epp-client/src/epp/request/contact/check.rs
+++ b/epp-client/src/epp/request/contact/check.rs
@@ -69,7 +69,7 @@ impl EppContactCheck {
         let contact_check = ContactCheck {
             list: ContactList {
                 xmlns: EPP_CONTACT_XMLNS.to_string(),
-                contact_ids: contact_ids,
+                contact_ids,
             },
         };
 

--- a/epp-client/src/epp/request/contact/check.rs
+++ b/epp-client/src/epp/request/contact/check.rs
@@ -63,7 +63,7 @@ impl EppContactCheck {
     pub fn new(contact_ids: Vec<&str>, client_tr_id: &str) -> EppContactCheck {
         let contact_ids = contact_ids
             .iter()
-            .filter_map(|d| Some(d.to_string_value()))
+            .map(|d| d.to_string_value())
             .collect::<Vec<StringValue>>();
 
         let contact_check = ContactCheck {

--- a/epp-client/src/epp/request/contact/create.rs
+++ b/epp-client/src/epp/request/contact/create.rs
@@ -99,8 +99,8 @@ impl EppContactCreate {
             contact: Contact {
                 xmlns: EPP_CONTACT_XMLNS.to_string(),
                 id: id.to_string_value(),
-                postal_info: postal_info,
-                voice: voice,
+                postal_info,
+                voice,
                 fax: None,
                 email: email.to_string_value(),
                 auth_info: data::AuthInfo::new(auth_password),

--- a/epp-client/src/epp/request/contact/update.rs
+++ b/epp-client/src/epp/request/contact/update.rs
@@ -151,7 +151,7 @@ impl EppContactUpdate {
                     email: Some(res_data.info_data.email.clone()),
                     postal_info: Some(res_data.info_data.postal_info.clone()),
                     voice: Some(res_data.info_data.voice.clone()),
-                    fax: res_data.info_data.fax.clone(),
+                    fax: res_data.info_data.fax,
                     auth_info: None,
                 });
                 Ok(())

--- a/epp-client/src/epp/request/contact/update.rs
+++ b/epp-client/src/epp/request/contact/update.rs
@@ -124,9 +124,8 @@ impl EppContactUpdate {
 
     /// Sets the data for the &lt;fax&gt; tag under &lt;chg&gt; for the contact update request
     pub fn set_fax(&mut self, fax: Phone) {
-        match &mut self.data.command.contact.change_info {
-            Some(ref mut info) => info.fax = Some(fax),
-            _ => (),
+        if let Some(info) = &mut self.data.command.contact.change_info {
+            info.fax = Some(fax)
         }
     }
 

--- a/epp-client/src/epp/request/domain/check.rs
+++ b/epp-client/src/epp/request/domain/check.rs
@@ -63,7 +63,7 @@ impl EppDomainCheck {
     pub fn new(domains: Vec<&str>, client_tr_id: &str) -> EppDomainCheck {
         let domains = domains
             .iter()
-            .filter_map(|d| Some(d.to_string_value()))
+            .map(|d| d.to_string_value())
             .collect::<Vec<StringValue>>();
 
         let domain_check = DomainCheck {

--- a/epp-client/src/epp/request/domain/check.rs
+++ b/epp-client/src/epp/request/domain/check.rs
@@ -69,7 +69,7 @@ impl EppDomainCheck {
         let domain_check = DomainCheck {
             list: DomainList {
                 xmlns: EPP_DOMAIN_XMLNS.to_string(),
-                domains: domains,
+                domains,
             },
         };
 

--- a/epp-client/src/epp/request/domain/rgp/report.rs
+++ b/epp-client/src/epp/request/domain/rgp/report.rs
@@ -161,7 +161,7 @@ impl EppDomainRgpRestoreReport {
                                 .to_rfc3339_opts(SecondsFormat::AutoSi, true)
                                 .to_string_value(),
                             restore_reason: restore_reason.to_string_value(),
-                            statements: statements,
+                            statements,
                             other: other.to_string_value(),
                         },
                     },

--- a/epp-client/src/epp/request/domain/rgp/report.rs
+++ b/epp-client/src/epp/request/domain/rgp/report.rs
@@ -116,6 +116,7 @@ pub struct RgpRestoreReport {
 
 impl EppDomainRgpRestoreReport {
     /// Creates a new EppObject for domain rgp restore report corresponding to the &lt;epp&gt; tag in EPP XML
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: &str,
         pre_data: &str,

--- a/epp-client/src/epp/request/host/check.rs
+++ b/epp-client/src/epp/request/host/check.rs
@@ -69,7 +69,7 @@ impl EppHostCheck {
         let host_check = HostCheck {
             list: HostList {
                 xmlns: EPP_HOST_XMLNS.to_string(),
-                hosts: hosts,
+                hosts,
             },
         };
 

--- a/epp-client/src/epp/request/host/check.rs
+++ b/epp-client/src/epp/request/host/check.rs
@@ -63,7 +63,7 @@ impl EppHostCheck {
     pub fn new(hosts: Vec<&str>, client_tr_id: &str) -> EppHostCheck {
         let hosts = hosts
             .iter()
-            .filter_map(|d| Some(d.to_string_value()))
+            .map(|d| d.to_string_value())
             .collect::<Vec<StringValue>>();
 
         let host_check = HostCheck {

--- a/epp-client/src/epp/response.rs
+++ b/epp-client/src/epp/response.rs
@@ -261,14 +261,14 @@ impl<T, E: ElementName> CommandResponseWithExtension<T, E> {
     /// Returns the data under the corresponding &lt;resData&gt; from the EPP XML
     pub fn res_data(&self) -> Option<&T> {
         match &self.res_data {
-            Some(res_data) => Some(&res_data),
+            Some(res_data) => Some(res_data),
             None => None,
         }
     }
     /// Returns the data under the corresponding <msgQ> from the EPP XML
     pub fn message_queue(&self) -> Option<&MessageQueue> {
         match &self.message_queue {
-            Some(queue) => Some(&queue),
+            Some(queue) => Some(queue),
             None => None,
         }
     }

--- a/epp-client/src/epp/xml/quick_xml.rs
+++ b/epp-client/src/epp/xml/quick_xml.rs
@@ -24,9 +24,10 @@ impl<T: Serialize + DeserializeOwned + ElementName + Debug> EppXml for EppObject
         let object: Self::Output = match from_str(epp_xml) {
             Ok(v) => v,
             Err(e) => {
-                return Err(error::Error::EppDeserializationError(
-                    format!("epp-client Deserialization Error: {}", e),
-                ))
+                return Err(error::Error::EppDeserializationError(format!(
+                    "epp-client Deserialization Error: {}",
+                    e
+                )))
             }
         };
         // object.xml = Some(epp_xml.to_string());

--- a/epp-client/src/epp/xml/quick_xml.rs
+++ b/epp-client/src/epp/xml/quick_xml.rs
@@ -25,7 +25,7 @@ impl<T: Serialize + DeserializeOwned + ElementName + Debug> EppXml for EppObject
             Ok(v) => v,
             Err(e) => {
                 return Err(error::Error::EppDeserializationError(
-                    format!("epp-client Deserialization Error: {}", e).to_string(),
+                    format!("epp-client Deserialization Error: {}", e),
                 ))
             }
         };

--- a/epp-client/src/error.rs
+++ b/epp-client/src/error.rs
@@ -34,7 +34,7 @@ impl Display for Error {
 
 impl From<std::boxed::Box<dyn std::error::Error>> for Error {
     fn from(e: std::boxed::Box<dyn std::error::Error>) -> Self {
-        Self::Other(format!("{:?}", e).to_string())
+        Self::Other(format!("{:?}", e))
     }
 }
 

--- a/epp-client/src/tests/mod.rs
+++ b/epp-client/src/tests/mod.rs
@@ -17,8 +17,8 @@ fn get_xml(path: &str) -> Result<String, Box<dyn Error>> {
     let mut buf = String::new();
 
     f.read_to_string(&mut buf)?;
-    if buf.len() > 0 {
-        let mat = Regex::new(r"\?>").unwrap().find(&buf.as_str()).unwrap();
+    if !buf.is_empty() {
+        let mat = Regex::new(r"\?>").unwrap().find(buf.as_str()).unwrap();
         let start = mat.end();
         buf = format!(
             "{}\r\n{}",


### PR DESCRIPTION
This pull request applies the changes produced by:

- `cargo fmt`
- `cargo clippy --fix`

It also makes the minimal changes required to satisfy the remaining `cargo clippy` recommendations.

Keeping the code formatted with `cargo fmt` should lead to more consistent code style and reduce diff sizes.  Additionally, I think keeping `cargo clippy` happy leads to cleaner code and reduces warning noise during builds.

This change should be a style change only and should not make any functional changes.

I've also added a GitHub Actions workflow to run these checks automatically. You can see an example of this running here: https://github.com/nrempel/epp-client/pull/3. I can't seem to see the workflow running yet but I think this is because I don't have permission.