### PR TITLE
Remove xsi attributes

### DIFF
--- a/epp-client/src/epp/object.rs
+++ b/epp-client/src/epp/object.rs
@@ -6,7 +6,7 @@ use epp_client_macros::*;
 use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
 use std::fmt::Display;
 
-use crate::epp::xml::{EPP_XMLNS, EPP_XMLNS_XSI, EPP_XSI_SCHEMA_LOCATION};
+use crate::epp::xml::EPP_XMLNS;
 
 /// Wraps String for easier serialization to and from values that are inner text
 /// for tags rather than attributes
@@ -59,12 +59,6 @@ pub struct EmptyTag;
 pub struct EppObject<T: ElementName> {
     /// XML namespace for the &lt;epp&gt; tag
     pub xmlns: String,
-    /// Schema namespace for the &lt;epp&gt; tag
-    #[serde(rename = "xmlns:xsi")]
-    pub xmlns_xsi: String,
-    /// Schema location attribute for &lt;epp&gt;
-    #[serde(rename = "xsi:schemaLocation")]
-    pub xsi_schema_location: String,
     /// the request or response object that is set or received in the EPP XML document
     #[serde(alias = "greeting", alias = "response")]
     pub data: T,
@@ -82,8 +76,6 @@ impl<T: ElementName + Serialize> Serialize for EppObject<T> {
 
         let mut state = serializer.serialize_struct("epp", 4)?;
         state.serialize_field("xmlns", &self.xmlns)?;
-        state.serialize_field("xmlns:xsi", &self.xmlns_xsi)?;
-        state.serialize_field("xsi:schemaLocation", &self.xsi_schema_location)?;
         state.serialize_field(data_name, &self.data)?;
         state.end()
     }
@@ -158,8 +150,6 @@ impl<T: ElementName> EppObject<T> {
             // xml: None,
             data,
             xmlns: EPP_XMLNS.to_string(),
-            xmlns_xsi: EPP_XMLNS_XSI.to_string(),
-            xsi_schema_location: EPP_XSI_SCHEMA_LOCATION.to_string(),
         }
     }
 }

--- a/epp-client/src/epp/xml.rs
+++ b/epp-client/src/epp/xml.rs
@@ -8,8 +8,6 @@ use crate::error;
 
 pub const EPP_XML_HEADER: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="no"?>"#;
 pub const EPP_XMLNS: &str = "urn:ietf:params:xml:ns:epp-1.0";
-pub const EPP_XMLNS_XSI: &str = "http://www.w3.org/2001/XMLSchema-instance";
-pub const EPP_XSI_SCHEMA_LOCATION: &str = "urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd";
 
 pub const EPP_DOMAIN_XMLNS: &str = "urn:ietf:params:xml:ns:domain-1.0";
 pub const EPP_CONTACT_XMLNS: &str = "urn:ietf:params:xml:ns:contact-1.0";

--- a/epp-client/test/resources/request/contact/check.xml
+++ b/epp-client/test/resources/request/contact/check.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<check>
 			<check xmlns="urn:ietf:params:xml:ns:contact-1.0">

--- a/epp-client/test/resources/request/contact/create.xml
+++ b/epp-client/test/resources/request/contact/create.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<create>
 			<create xmlns="urn:ietf:params:xml:ns:contact-1.0">

--- a/epp-client/test/resources/request/contact/delete.xml
+++ b/epp-client/test/resources/request/contact/delete.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<delete>
 			<delete xmlns="urn:ietf:params:xml:ns:contact-1.0">

--- a/epp-client/test/resources/request/contact/info.xml
+++ b/epp-client/test/resources/request/contact/info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<info>
 			<info xmlns="urn:ietf:params:xml:ns:contact-1.0">

--- a/epp-client/test/resources/request/contact/update.xml
+++ b/epp-client/test/resources/request/contact/update.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<update>
 			<update xmlns="urn:ietf:params:xml:ns:contact-1.0">

--- a/epp-client/test/resources/request/domain/check.xml
+++ b/epp-client/test/resources/request/domain/check.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<check>
 			<check xmlns="urn:ietf:params:xml:ns:domain-1.0">

--- a/epp-client/test/resources/request/domain/create.xml
+++ b/epp-client/test/resources/request/domain/create.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<create>
 			<create xmlns="urn:ietf:params:xml:ns:domain-1.0">

--- a/epp-client/test/resources/request/domain/create_with_host_attr.xml
+++ b/epp-client/test/resources/request/domain/create_with_host_attr.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<create>
 			<create xmlns="urn:ietf:params:xml:ns:domain-1.0">

--- a/epp-client/test/resources/request/domain/create_with_host_obj.xml
+++ b/epp-client/test/resources/request/domain/create_with_host_obj.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<create>
 			<create xmlns="urn:ietf:params:xml:ns:domain-1.0">

--- a/epp-client/test/resources/request/domain/delete.xml
+++ b/epp-client/test/resources/request/domain/delete.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<delete>
 			<delete xmlns="urn:ietf:params:xml:ns:domain-1.0">

--- a/epp-client/test/resources/request/domain/info.xml
+++ b/epp-client/test/resources/request/domain/info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<info>
 			<info xmlns="urn:ietf:params:xml:ns:domain-1.0">

--- a/epp-client/test/resources/request/domain/renew.xml
+++ b/epp-client/test/resources/request/domain/renew.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<renew>
 			<renew xmlns="urn:ietf:params:xml:ns:domain-1.0">

--- a/epp-client/test/resources/request/domain/rgp_restore_report.xml
+++ b/epp-client/test/resources/request/domain/rgp_restore_report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<update>
 			<update xmlns="urn:ietf:params:xml:ns:domain-1.0">

--- a/epp-client/test/resources/request/domain/rgp_restore_request.xml
+++ b/epp-client/test/resources/request/domain/rgp_restore_request.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<update>
 			<update xmlns="urn:ietf:params:xml:ns:domain-1.0">

--- a/epp-client/test/resources/request/domain/transfer_approve.xml
+++ b/epp-client/test/resources/request/domain/transfer_approve.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<transfer op="approve">
 			<transfer xmlns="urn:ietf:params:xml:ns:domain-1.0">

--- a/epp-client/test/resources/request/domain/transfer_cancel.xml
+++ b/epp-client/test/resources/request/domain/transfer_cancel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<transfer op="cancel">
 			<transfer xmlns="urn:ietf:params:xml:ns:domain-1.0">

--- a/epp-client/test/resources/request/domain/transfer_query.xml
+++ b/epp-client/test/resources/request/domain/transfer_query.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<transfer op="query">
 			<transfer xmlns="urn:ietf:params:xml:ns:domain-1.0">

--- a/epp-client/test/resources/request/domain/transfer_reject.xml
+++ b/epp-client/test/resources/request/domain/transfer_reject.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<transfer op="reject">
 			<transfer xmlns="urn:ietf:params:xml:ns:domain-1.0">

--- a/epp-client/test/resources/request/domain/transfer_request.xml
+++ b/epp-client/test/resources/request/domain/transfer_request.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<transfer op="request">
 			<transfer xmlns="urn:ietf:params:xml:ns:domain-1.0">

--- a/epp-client/test/resources/request/domain/update.xml
+++ b/epp-client/test/resources/request/domain/update.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<update>
 			<update xmlns="urn:ietf:params:xml:ns:domain-1.0">

--- a/epp-client/test/resources/request/hello.xml
+++ b/epp-client/test/resources/request/hello.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
     <hello/>
 </epp>

--- a/epp-client/test/resources/request/host/check.xml
+++ b/epp-client/test/resources/request/host/check.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<check>
 			<check xmlns="urn:ietf:params:xml:ns:host-1.0">

--- a/epp-client/test/resources/request/host/create.xml
+++ b/epp-client/test/resources/request/host/create.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<create>
 			<create xmlns="urn:ietf:params:xml:ns:host-1.0">

--- a/epp-client/test/resources/request/host/delete.xml
+++ b/epp-client/test/resources/request/host/delete.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<delete>
 			<delete xmlns="urn:ietf:params:xml:ns:host-1.0">

--- a/epp-client/test/resources/request/host/info.xml
+++ b/epp-client/test/resources/request/host/info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<info>
 			<info xmlns="urn:ietf:params:xml:ns:host-1.0">

--- a/epp-client/test/resources/request/host/update.xml
+++ b/epp-client/test/resources/request/host/update.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<update>
 			<update xmlns="urn:ietf:params:xml:ns:host-1.0">

--- a/epp-client/test/resources/request/login.xml
+++ b/epp-client/test/resources/request/login.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<login>
 			<clID>username</clID>

--- a/epp-client/test/resources/request/logout.xml
+++ b/epp-client/test/resources/request/logout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<logout/>
 		<clTRID>cltrid:1626454866</clTRID>

--- a/epp-client/test/resources/request/message/ack.xml
+++ b/epp-client/test/resources/request/message/ack.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<poll op="ack" msgID="12345"/>
 		<clTRID>cltrid:1626454866</clTRID>

--- a/epp-client/test/resources/request/message/poll.xml
+++ b/epp-client/test/resources/request/message/poll.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<command>
 		<poll op="req"/>
 		<clTRID>cltrid:1626454866</clTRID>

--- a/epp-client/test/resources/response/contact/check.xml
+++ b/epp-client/test/resources/response/contact/check.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/contact/create.xml
+++ b/epp-client/test/resources/response/contact/create.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/contact/delete.xml
+++ b/epp-client/test/resources/response/contact/delete.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/contact/info.xml
+++ b/epp-client/test/resources/response/contact/info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/contact/update.xml
+++ b/epp-client/test/resources/response/contact/update.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/domain/check.xml
+++ b/epp-client/test/resources/response/domain/check.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/domain/create.xml
+++ b/epp-client/test/resources/response/domain/create.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/domain/delete.xml
+++ b/epp-client/test/resources/response/domain/delete.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/domain/info.xml
+++ b/epp-client/test/resources/response/domain/info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/domain/renew.xml
+++ b/epp-client/test/resources/response/domain/renew.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/domain/rgp_restore.xml
+++ b/epp-client/test/resources/response/domain/rgp_restore.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg lang="en">Command completed successfully</msg>

--- a/epp-client/test/resources/response/domain/transfer_approve.xml
+++ b/epp-client/test/resources/response/domain/transfer_approve.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/domain/transfer_cancel.xml
+++ b/epp-client/test/resources/response/domain/transfer_cancel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/domain/transfer_query.xml
+++ b/epp-client/test/resources/response/domain/transfer_query.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/domain/transfer_reject.xml
+++ b/epp-client/test/resources/response/domain/transfer_reject.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/domain/transfer_request.xml
+++ b/epp-client/test/resources/response/domain/transfer_request.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1001">
 			<msg>Command completed successfully; action pending</msg>

--- a/epp-client/test/resources/response/domain/update.xml
+++ b/epp-client/test/resources/response/domain/update.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/error.xml
+++ b/epp-client/test/resources/response/error.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="2303">
 			<msg>Object does not exist</msg>

--- a/epp-client/test/resources/response/greeting.xml
+++ b/epp-client/test/resources/response/greeting.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
     <greeting>
         <svID>ISPAPI EPP Server</svID>
         <svDate>2021-07-25T14:51:17.0Z</svDate>

--- a/epp-client/test/resources/response/host/check.xml
+++ b/epp-client/test/resources/response/host/check.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/host/create.xml
+++ b/epp-client/test/resources/response/host/create.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/host/delete.xml
+++ b/epp-client/test/resources/response/host/delete.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/host/info.xml
+++ b/epp-client/test/resources/response/host/info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/host/update.xml
+++ b/epp-client/test/resources/response/host/update.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/login.xml
+++ b/epp-client/test/resources/response/login.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/logout.xml
+++ b/epp-client/test/resources/response/logout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1500">
 			<msg>Command completed successfully; ending session</msg>

--- a/epp-client/test/resources/response/message/ack.xml
+++ b/epp-client/test/resources/response/message/ack.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1000">
 			<msg>Command completed successfully</msg>

--- a/epp-client/test/resources/response/message/poll.xml
+++ b/epp-client/test/resources/response/message/poll.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
 	<response>
 		<result code="1301">
 			<msg>Command completed successfully; ack to dequeue</msg>


### PR DESCRIPTION
I ran into this connecting to a registry—it appears that xsi attributes are no longer a part of the XML payload.

I see them in [rfc3730](https://datatracker.ietf.org/doc/html/rfc3730) but they seem to be absent in the latest [rfc5730](https://datatracker.ietf.org/doc/html/rfc5730).

Have you seen these attributes in other registries like hexonet? I'm not sure if these should be optional instead.