### PR TITLE
Call to epp logout made explicit and Drop impl removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ async fn main() {
     response.data.res_data.unwrap().check_data.domain_list
         .iter()
         .for_each(|chk| println!("Domain: {}, Available: {}", chk.domain.name, chk.domain.available));
+
+    client.close().await.unwrap();
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ async fn main() {
         .iter()
         .for_each(|chk| println!("Domain: {}, Available: {}", chk.domain.name, chk.domain.available));
 
-    client.close().await.unwrap();
+    client.logout().await.unwrap();
 }
 ```
 

--- a/epp-client/Cargo.toml
+++ b/epp-client/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/masalachai/epp-client"
 epp-client-macros = "0.1" # { path = "../epp-client-macros" }
 bytes = "1"
 chrono = "0.4"
-futures = "0.3"
 env_logger = "0.9"
 log = "0.4"
 quick-xml = { version = "0.22", features = [ "serialize" ] }

--- a/epp-client/src/config.rs
+++ b/epp-client/src/config.rs
@@ -50,8 +50,8 @@ use std::{fs, io};
 /// Paths to the client certificate and client key PEM files
 #[derive(Serialize, Deserialize, Debug)]
 pub struct EppClientTlsFiles {
-    cert_chain: String,
-    key: String,
+    pub cert_chain: String,
+    pub key: String,
 }
 
 /// Connection details to connect to and authenticate with a registry

--- a/epp-client/src/connection/client.rs
+++ b/epp-client/src/connection/client.rs
@@ -184,12 +184,10 @@ impl EppClient {
         let client_tr_id = generate_client_tr_id(&self.credentials.0).unwrap();
         let epp_logout = EppLogout::new(client_tr_id.as_str());
 
-        self.transact::<_, EppLogoutResponse>(&epp_logout).await
-    }
+        let response = self.transact::<_, EppLogoutResponse>(&epp_logout).await?;
 
-    pub async fn close(&mut self) -> Result<(), error::Error> {
-        self.logout().await?;
+        self.connection.shutdown().await?;
 
-        Ok(self.connection.close().await?)
+        Ok(response)
     }
 }

--- a/epp-client/src/connection/client.rs
+++ b/epp-client/src/connection/client.rs
@@ -46,7 +46,6 @@
 //! }
 //! ```
 
-use futures::executor::block_on;
 use std::time::SystemTime;
 use std::{error::Error, fmt::Debug};
 
@@ -187,10 +186,10 @@ impl EppClient {
 
         self.transact::<_, EppLogoutResponse>(&epp_logout).await
     }
-}
 
-impl Drop for EppClient {
-    fn drop(&mut self) {
-        let _ = block_on(self.logout());
+    pub async fn close(&mut self) -> Result<(), error::Error> {
+        self.logout().await?;
+
+        Ok(self.connection.close().await?)
     }
 }

--- a/epp-client/src/connection/registry.rs
+++ b/epp-client/src/connection/registry.rs
@@ -127,8 +127,8 @@ impl EppConnection {
         Ok(response)
     }
 
-    /// Closes the socket
-    pub async fn close(&mut self) -> Result<(), Box<dyn Error>> {
+    /// Closes the socket and shuts the connection
+    pub async fn shutdown(&mut self) -> Result<(), Box<dyn Error>> {
         info!("{}: Closing connection", self.registry);
 
         self.stream.writer.shutdown().await?;

--- a/epp-client/src/connection/registry.rs
+++ b/epp-client/src/connection/registry.rs
@@ -1,7 +1,6 @@
 //! Manages registry connections and reading/writing to them
 
 use bytes::BytesMut;
-use futures::executor::block_on;
 use rustls::{OwnedTrustAnchor, RootCertStore};
 use std::convert::TryInto;
 use std::sync::Arc;
@@ -129,17 +128,11 @@ impl EppConnection {
     }
 
     /// Closes the socket
-    async fn close(&mut self) -> Result<(), Box<dyn Error>> {
+    pub async fn close(&mut self) -> Result<(), Box<dyn Error>> {
         info!("{}: Closing connection", self.registry);
 
         self.stream.writer.shutdown().await?;
         Ok(())
-    }
-}
-
-impl Drop for EppConnection {
-    fn drop(&mut self) {
-        let _ = block_on(self.close());
     }
 }
 

--- a/epp-client/src/epp/request/contact/check.rs
+++ b/epp-client/src/epp/request/contact/check.rs
@@ -52,7 +52,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppContactCheck = EppObject<Command<ContactCheck>>;

--- a/epp-client/src/epp/request/contact/check.rs
+++ b/epp-client/src/epp/request/contact/check.rs
@@ -51,6 +51,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppContactCheckResponse>(&contact_check).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppContactCheck = EppObject<Command<ContactCheck>>;

--- a/epp-client/src/epp/request/contact/create.rs
+++ b/epp-client/src/epp/request/contact/create.rs
@@ -68,6 +68,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppContactCreateResponse>(&contact_create).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppContactCreate = EppObject<Command<ContactCreate>>;

--- a/epp-client/src/epp/request/contact/create.rs
+++ b/epp-client/src/epp/request/contact/create.rs
@@ -69,7 +69,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppContactCreate = EppObject<Command<ContactCreate>>;

--- a/epp-client/src/epp/request/contact/delete.rs
+++ b/epp-client/src/epp/request/contact/delete.rs
@@ -53,7 +53,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppContactDelete = EppObject<Command<ContactDelete>>;

--- a/epp-client/src/epp/request/contact/delete.rs
+++ b/epp-client/src/epp/request/contact/delete.rs
@@ -52,6 +52,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppContactDeleteResponse>(&contact_delete).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppContactDelete = EppObject<Command<ContactDelete>>;

--- a/epp-client/src/epp/request/contact/info.rs
+++ b/epp-client/src/epp/request/contact/info.rs
@@ -54,6 +54,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppContactInfoResponse>(&contact_info).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppContactInfo = EppObject<Command<ContactInfo>>;

--- a/epp-client/src/epp/request/contact/info.rs
+++ b/epp-client/src/epp/request/contact/info.rs
@@ -55,7 +55,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppContactInfo = EppObject<Command<ContactInfo>>;

--- a/epp-client/src/epp/request/contact/update.rs
+++ b/epp-client/src/epp/request/contact/update.rs
@@ -65,7 +65,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppContactUpdate = EppObject<Command<ContactUpdate>>;

--- a/epp-client/src/epp/request/contact/update.rs
+++ b/epp-client/src/epp/request/contact/update.rs
@@ -64,6 +64,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppContactUpdateResponse>(&contact_update).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppContactUpdate = EppObject<Command<ContactUpdate>>;

--- a/epp-client/src/epp/request/domain/check.rs
+++ b/epp-client/src/epp/request/domain/check.rs
@@ -53,7 +53,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppDomainCheck = EppObject<Command<DomainCheck>>;

--- a/epp-client/src/epp/request/domain/check.rs
+++ b/epp-client/src/epp/request/domain/check.rs
@@ -52,6 +52,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppDomainCheckResponse>(&domain_check).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppDomainCheck = EppObject<Command<DomainCheck>>;

--- a/epp-client/src/epp/request/domain/create.rs
+++ b/epp-client/src/epp/request/domain/create.rs
@@ -73,7 +73,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppDomainCreate = EppObject<Command<DomainCreate>>;

--- a/epp-client/src/epp/request/domain/create.rs
+++ b/epp-client/src/epp/request/domain/create.rs
@@ -72,6 +72,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppDomainCreateResponse>(&domain_create).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppDomainCreate = EppObject<Command<DomainCreate>>;

--- a/epp-client/src/epp/request/domain/delete.rs
+++ b/epp-client/src/epp/request/domain/delete.rs
@@ -50,7 +50,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppDomainDelete = EppObject<Command<DomainDelete>>;

--- a/epp-client/src/epp/request/domain/delete.rs
+++ b/epp-client/src/epp/request/domain/delete.rs
@@ -49,6 +49,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppDomainDeleteResponse>(&domain_delete).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppDomainDelete = EppObject<Command<DomainDelete>>;

--- a/epp-client/src/epp/request/domain/info.rs
+++ b/epp-client/src/epp/request/domain/info.rs
@@ -49,6 +49,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppDomainInfoResponse>(&domain_info).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppDomainInfo = EppObject<Command<DomainInfo>>;

--- a/epp-client/src/epp/request/domain/info.rs
+++ b/epp-client/src/epp/request/domain/info.rs
@@ -50,7 +50,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppDomainInfo = EppObject<Command<DomainInfo>>;

--- a/epp-client/src/epp/request/domain/renew.rs
+++ b/epp-client/src/epp/request/domain/renew.rs
@@ -57,7 +57,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppDomainRenew = EppObject<Command<DomainRenew>>;

--- a/epp-client/src/epp/request/domain/renew.rs
+++ b/epp-client/src/epp/request/domain/renew.rs
@@ -56,6 +56,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppDomainRenewResponse>(&domain_renew).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppDomainRenew = EppObject<Command<DomainRenew>>;

--- a/epp-client/src/epp/request/domain/rgp/report.rs
+++ b/epp-client/src/epp/request/domain/rgp/report.rs
@@ -80,7 +80,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppDomainRgpRestoreReport =

--- a/epp-client/src/epp/request/domain/rgp/report.rs
+++ b/epp-client/src/epp/request/domain/rgp/report.rs
@@ -79,6 +79,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppDomainRgpRestoreReportResponse>(&domain_restore_report).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppDomainRgpRestoreReport =

--- a/epp-client/src/epp/request/domain/rgp/request.rs
+++ b/epp-client/src/epp/request/domain/rgp/request.rs
@@ -56,6 +56,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppDomainRgpRestoreRequestResponse>(&domain_restore_req).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppDomainRgpRestoreRequest =

--- a/epp-client/src/epp/request/domain/rgp/request.rs
+++ b/epp-client/src/epp/request/domain/rgp/request.rs
@@ -57,7 +57,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppDomainRgpRestoreRequest =

--- a/epp-client/src/epp/request/domain/transfer.rs
+++ b/epp-client/src/epp/request/domain/transfer.rs
@@ -52,6 +52,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppDomainTransferRequestResponse>(&domain_transfer_request).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppDomainTransferRequest = EppObject<Command<DomainTransfer>>;
@@ -100,6 +102,8 @@ pub type EppDomainTransferRequest = EppObject<Command<DomainTransfer>>;
 ///     let response = client.transact::<_, EppDomainTransferApproveResponse>(&domain_transfer_approve).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppDomainTransferApprove = EppObject<Command<DomainTransfer>>;
@@ -148,6 +152,8 @@ pub type EppDomainTransferApprove = EppObject<Command<DomainTransfer>>;
 ///     let response = client.transact::<_, EppDomainTransferRejectResponse>(&domain_transfer_reject).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppDomainTransferReject = EppObject<Command<DomainTransfer>>;
@@ -196,6 +202,8 @@ pub type EppDomainTransferReject = EppObject<Command<DomainTransfer>>;
 ///     let response = client.transact::<_, EppDomainTransferCancelResponse>(&domain_transfer_cancel).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppDomainTransferCancel = EppObject<Command<DomainTransfer>>;
@@ -244,6 +252,8 @@ pub type EppDomainTransferCancel = EppObject<Command<DomainTransfer>>;
 ///     let response = client.transact::<_, EppDomainTransferQueryResponse>(&domain_transfer_query).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppDomainTransferQuery = EppObject<Command<DomainTransfer>>;

--- a/epp-client/src/epp/request/domain/transfer.rs
+++ b/epp-client/src/epp/request/domain/transfer.rs
@@ -53,7 +53,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppDomainTransferRequest = EppObject<Command<DomainTransfer>>;
@@ -103,7 +103,7 @@ pub type EppDomainTransferRequest = EppObject<Command<DomainTransfer>>;
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppDomainTransferApprove = EppObject<Command<DomainTransfer>>;
@@ -153,7 +153,7 @@ pub type EppDomainTransferApprove = EppObject<Command<DomainTransfer>>;
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppDomainTransferReject = EppObject<Command<DomainTransfer>>;
@@ -203,7 +203,7 @@ pub type EppDomainTransferReject = EppObject<Command<DomainTransfer>>;
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppDomainTransferCancel = EppObject<Command<DomainTransfer>>;
@@ -253,7 +253,7 @@ pub type EppDomainTransferCancel = EppObject<Command<DomainTransfer>>;
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppDomainTransferQuery = EppObject<Command<DomainTransfer>>;

--- a/epp-client/src/epp/request/domain/update.rs
+++ b/epp-client/src/epp/request/domain/update.rs
@@ -77,7 +77,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppDomainUpdate = EppObject<Command<DomainUpdate<HostObjList>>>;

--- a/epp-client/src/epp/request/domain/update.rs
+++ b/epp-client/src/epp/request/domain/update.rs
@@ -76,6 +76,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppDomainUpdateResponse>(&domain_update).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppDomainUpdate = EppObject<Command<DomainUpdate<HostObjList>>>;

--- a/epp-client/src/epp/request/host/check.rs
+++ b/epp-client/src/epp/request/host/check.rs
@@ -52,6 +52,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppHostCheckResponse>(&host_check).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppHostCheck = EppObject<Command<HostCheck>>;

--- a/epp-client/src/epp/request/host/check.rs
+++ b/epp-client/src/epp/request/host/check.rs
@@ -53,7 +53,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppHostCheck = EppObject<Command<HostCheck>>;

--- a/epp-client/src/epp/request/host/create.rs
+++ b/epp-client/src/epp/request/host/create.rs
@@ -58,7 +58,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppHostCreate = EppObject<Command<HostCreate>>;

--- a/epp-client/src/epp/request/host/create.rs
+++ b/epp-client/src/epp/request/host/create.rs
@@ -57,6 +57,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppHostCreateResponse>(&host_create).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppHostCreate = EppObject<Command<HostCreate>>;

--- a/epp-client/src/epp/request/host/delete.rs
+++ b/epp-client/src/epp/request/host/delete.rs
@@ -49,6 +49,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppHostDeleteResponse>(&host_delete).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppHostDelete = EppObject<Command<HostDelete>>;

--- a/epp-client/src/epp/request/host/delete.rs
+++ b/epp-client/src/epp/request/host/delete.rs
@@ -50,7 +50,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppHostDelete = EppObject<Command<HostDelete>>;

--- a/epp-client/src/epp/request/host/info.rs
+++ b/epp-client/src/epp/request/host/info.rs
@@ -50,7 +50,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppHostInfo = EppObject<Command<HostInfo>>;

--- a/epp-client/src/epp/request/host/info.rs
+++ b/epp-client/src/epp/request/host/info.rs
@@ -49,6 +49,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppHostInfoResponse>(&host_info).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppHostInfo = EppObject<Command<HostInfo>>;

--- a/epp-client/src/epp/request/host/update.rs
+++ b/epp-client/src/epp/request/host/update.rs
@@ -74,7 +74,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppHostUpdate = EppObject<Command<HostUpdate>>;

--- a/epp-client/src/epp/request/host/update.rs
+++ b/epp-client/src/epp/request/host/update.rs
@@ -73,6 +73,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppHostUpdateResponse>(&host_update).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppHostUpdate = EppObject<Command<HostUpdate>>;

--- a/epp-client/src/epp/request/message/ack.rs
+++ b/epp-client/src/epp/request/message/ack.rs
@@ -48,7 +48,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppMessageAck = EppObject<Command<MessageAck>>;

--- a/epp-client/src/epp/request/message/ack.rs
+++ b/epp-client/src/epp/request/message/ack.rs
@@ -47,6 +47,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppMessageAckResponse>(&message_ack).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppMessageAck = EppObject<Command<MessageAck>>;

--- a/epp-client/src/epp/request/message/poll.rs
+++ b/epp-client/src/epp/request/message/poll.rs
@@ -48,6 +48,8 @@ use serde::{Deserialize, Serialize};
 ///     let response = client.transact::<_, EppMessagePollResponse>(&message_poll).await.unwrap();
 ///
 ///     println!("{:?}", response);
+///
+///     client.close().await.unwrap();
 /// }
 /// ```
 pub type EppMessagePoll = EppObject<Command<MessagePoll>>;

--- a/epp-client/src/epp/request/message/poll.rs
+++ b/epp-client/src/epp/request/message/poll.rs
@@ -49,7 +49,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     println!("{:?}", response);
 ///
-///     client.close().await.unwrap();
+///     client.logout().await.unwrap();
 /// }
 /// ```
 pub type EppMessagePoll = EppObject<Command<MessagePoll>>;


### PR DESCRIPTION
@nrempel 

I have removed the `impl Drop` for `EppClient` and `EppConnection` and added a `close()` function to be called explicitly to logout and close the connection. Let me know if we should add anything else in this change.