### PR TITLE
Replace StringValueTrait with From impls

### DIFF
--- a/epp-client/src/epp/object.rs
+++ b/epp-client/src/epp/object.rs
@@ -10,14 +10,8 @@ use crate::epp::xml::EPP_XMLNS;
 
 /// Wraps String for easier serialization to and from values that are inner text
 /// for tags rather than attributes
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct StringValue(String);
-
-impl Default for StringValue {
-    fn default() -> Self {
-        Self(String::from(""))
-    }
-}
 
 impl Display for StringValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -25,20 +19,15 @@ impl Display for StringValue {
     }
 }
 
-/// Trait for StringValue type to add easier conversion from str and String
-pub trait StringValueTrait {
-    fn to_string_value(&self) -> StringValue;
-}
-
-impl StringValueTrait for &str {
-    fn to_string_value(&self) -> StringValue {
-        StringValue(self.to_string())
+impl From<&str> for StringValue {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
     }
 }
 
-impl StringValueTrait for String {
-    fn to_string_value(&self) -> StringValue {
-        StringValue(self.to_string())
+impl From<String> for StringValue {
+    fn from(s: String) -> Self {
+        Self(s)
     }
 }
 
@@ -93,8 +82,8 @@ impl Options {
     /// Creates an Options object with version and lang data
     pub fn build(version: &str, lang: &str) -> Options {
         Options {
-            version: version.to_string_value(),
-            lang: lang.to_string_value(),
+            version: version.into(),
+            lang: lang.into(),
         }
     }
 }

--- a/epp-client/src/epp/object/data.rs
+++ b/epp-client/src/epp/object/data.rs
@@ -1,6 +1,6 @@
 //! Common data types included in EPP Requests and Responses
 
-use crate::epp::object::{StringValue, StringValueTrait};
+use crate::epp::object::StringValue;
 use serde::{Deserialize, Serialize};
 
 /// The &lt;status&gt; attribute on EPP XML for domain transactions
@@ -217,7 +217,7 @@ impl DomainAuthInfo {
     /// Creates a DomainAuthInfo instance with the given password
     pub fn new(password: &str) -> DomainAuthInfo {
         DomainAuthInfo {
-            password: password.to_string_value(),
+            password: password.into(),
         }
     }
 }
@@ -226,7 +226,7 @@ impl ContactAuthInfo {
     /// Creates a ContactAuthInfo instance with the given password
     pub fn new(password: &str) -> ContactAuthInfo {
         ContactAuthInfo {
-            password: password.to_string_value(),
+            password: password.into(),
         }
     }
 }
@@ -234,23 +234,20 @@ impl ContactAuthInfo {
 impl Address {
     /// Creates a new Address instance
     pub fn new(
-        street: Vec<&str>,
+        street: &[&str],
         city: &str,
         province: &str,
         postal_code: &str,
         country_code: &str,
     ) -> Address {
-        let street = street
-            .iter()
-            .map(|s| s.to_string_value())
-            .collect::<Vec<StringValue>>();
+        let street = street.iter().map(|&s| s.into()).collect();
 
         Address {
             street,
-            city: city.to_string_value(),
-            province: province.to_string_value(),
-            postal_code: postal_code.to_string_value(),
-            country_code: country_code.to_string_value(),
+            city: city.into(),
+            province: province.into(),
+            postal_code: postal_code.into(),
+            country_code: country_code.into(),
         }
     }
 }
@@ -260,8 +257,8 @@ impl PostalInfo {
     pub fn new(info_type: &str, name: &str, organization: &str, address: Address) -> PostalInfo {
         PostalInfo {
             info_type: info_type.to_string(),
-            name: name.to_string_value(),
-            organization: organization.to_string_value(),
+            name: name.into(),
+            organization: organization.into(),
             address,
         }
     }

--- a/epp-client/src/epp/request.rs
+++ b/epp-client/src/epp/request.rs
@@ -11,7 +11,6 @@ use std::time::SystemTime;
 
 use crate::epp::object::{
     ElementName, EmptyTag, EppObject, Extension, Options, ServiceExtension, Services, StringValue,
-    StringValueTrait,
 };
 use crate::epp::xml::{EPP_CONTACT_XMLNS, EPP_DOMAIN_XMLNS, EPP_HOST_XMLNS, EPP_LANG, EPP_VERSION};
 use epp_client_macros::*;
@@ -62,7 +61,7 @@ impl<T: ElementName> Command<T> {
         Command {
             command,
             extension: None,
-            client_tr_id: client_tr_id.to_string_value(),
+            client_tr_id: client_tr_id.into(),
         }
     }
 }
@@ -73,7 +72,7 @@ impl<T: ElementName, E: ElementName> CommandWithExtension<T, E> {
         CommandWithExtension {
             command,
             extension: Some(Extension { data: ext }),
-            client_tr_id: client_tr_id.to_string_value(),
+            client_tr_id: client_tr_id.into(),
         }
     }
 }
@@ -127,24 +126,22 @@ impl EppLogin {
         ext_uris: &Option<Vec<String>>,
         client_tr_id: &str,
     ) -> EppLogin {
-        let ext_uris = ext_uris.as_ref().map(|uris| {
-            uris.iter()
-                .map(|u| u.to_string_value())
-                .collect::<Vec<StringValue>>()
-        });
+        let ext_uris = ext_uris
+            .as_ref()
+            .map(|uris| uris.iter().map(|u| u.as_str().into()).collect());
 
         let login = Login {
-            username: username.to_string_value(),
-            password: password.to_string_value(),
+            username: username.into(),
+            password: password.into(),
             options: Options {
-                version: EPP_VERSION.to_string_value(),
-                lang: EPP_LANG.to_string_value(),
+                version: EPP_VERSION.into(),
+                lang: EPP_LANG.into(),
             },
             services: Services {
                 obj_uris: vec![
-                    EPP_HOST_XMLNS.to_string_value(),
-                    EPP_CONTACT_XMLNS.to_string_value(),
-                    EPP_DOMAIN_XMLNS.to_string_value(),
+                    EPP_HOST_XMLNS.into(),
+                    EPP_CONTACT_XMLNS.into(),
+                    EPP_DOMAIN_XMLNS.into(),
                 ],
                 svc_ext: Some(ServiceExtension { ext_uris }),
             },
@@ -153,7 +150,7 @@ impl EppLogin {
         EppObject::build(Command::<Login> {
             command: login,
             extension: None,
-            client_tr_id: client_tr_id.to_string_value(),
+            client_tr_id: client_tr_id.into(),
         })
     }
 
@@ -179,7 +176,7 @@ impl EppLogout {
         EppObject::build(Command::<Logout> {
             command: Logout,
             extension: None,
-            client_tr_id: client_tr_id.to_string_value(),
+            client_tr_id: client_tr_id.into(),
         })
     }
 }

--- a/epp-client/src/epp/request/contact/check.rs
+++ b/epp-client/src/epp/request/contact/check.rs
@@ -1,7 +1,7 @@
 /// Types for EPP contact check request
 use epp_client_macros::*;
 
-use crate::epp::object::{ElementName, EppObject, StringValue, StringValueTrait};
+use crate::epp::object::{ElementName, EppObject, StringValue};
 use crate::epp::request::Command;
 use crate::epp::xml::EPP_CONTACT_XMLNS;
 use serde::{Deserialize, Serialize};
@@ -43,7 +43,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     // Create an EppContactCheck instance
 ///     let contact_check = EppContactCheck::new(
-///         vec!["epp-client-c1", "epp-client-c2"],
+///         &["epp-client-c1", "epp-client-c2"],
 ///         generate_client_tr_id(&client).as_str()
 ///     );
 ///
@@ -79,10 +79,10 @@ pub struct ContactCheck {
 
 impl EppContactCheck {
     /// Creates an EppObject corresponding to the &lt;epp&gt; tag with data for a contact check request
-    pub fn new(contact_ids: Vec<&str>, client_tr_id: &str) -> EppContactCheck {
+    pub fn new(contact_ids: &[&str], client_tr_id: &str) -> EppContactCheck {
         let contact_ids = contact_ids
             .iter()
-            .map(|d| d.to_string_value())
+            .map(|&d| d.into())
             .collect::<Vec<StringValue>>();
 
         let contact_check = ContactCheck {

--- a/epp-client/src/epp/request/contact/create.rs
+++ b/epp-client/src/epp/request/contact/create.rs
@@ -3,7 +3,7 @@
 use epp_client_macros::*;
 
 use crate::epp::object::data;
-use crate::epp::object::{ElementName, EppObject, StringValue, StringValueTrait};
+use crate::epp::object::{ElementName, EppObject, StringValue};
 use crate::epp::request::Command;
 use crate::epp::xml::EPP_CONTACT_XMLNS;
 use serde::{Deserialize, Serialize};
@@ -46,7 +46,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     // Create the address, postal_info, voice instances
 ///     let street = vec!["58", "Orchid Road"];
-///     let address = Address::new(street, "New York", "New York", "392374", "US");
+///     let address = Address::new(&street, "New York", "New York", "392374", "US");
 ///     let postal_info = PostalInfo::new("int", "John Doe", "Acme Widgets", address);
 ///     let mut voice = Phone::new("+1.47237942");
 ///     voice.set_extension("123");
@@ -122,11 +122,11 @@ impl EppContactCreate {
         let contact_create = ContactCreate {
             contact: Contact {
                 xmlns: EPP_CONTACT_XMLNS.to_string(),
-                id: id.to_string_value(),
+                id: id.into(),
                 postal_info,
                 voice,
                 fax: None,
-                email: email.to_string_value(),
+                email: email.into(),
                 auth_info: data::ContactAuthInfo::new(auth_password),
             },
         };

--- a/epp-client/src/epp/request/contact/delete.rs
+++ b/epp-client/src/epp/request/contact/delete.rs
@@ -2,7 +2,7 @@
 
 use epp_client_macros::*;
 
-use crate::epp::object::{ElementName, EppObject, StringValue, StringValueTrait};
+use crate::epp::object::{ElementName, EppObject, StringValue};
 use crate::epp::request::Command;
 use crate::epp::xml::EPP_CONTACT_XMLNS;
 use serde::{Deserialize, Serialize};
@@ -84,7 +84,7 @@ impl EppContactDelete {
         let contact_delete = ContactDelete {
             contact: ContactDeleteData {
                 xmlns: EPP_CONTACT_XMLNS.to_string(),
-                id: id.to_string_value(),
+                id: id.into(),
             },
         };
 

--- a/epp-client/src/epp/request/contact/info.rs
+++ b/epp-client/src/epp/request/contact/info.rs
@@ -3,7 +3,7 @@
 use epp_client_macros::*;
 
 use crate::epp::object::data::ContactAuthInfo;
-use crate::epp::object::{ElementName, EppObject, StringValue, StringValueTrait};
+use crate::epp::object::{ElementName, EppObject, StringValue};
 use crate::epp::request::Command;
 use crate::epp::xml::EPP_CONTACT_XMLNS;
 use serde::{Deserialize, Serialize};
@@ -89,7 +89,7 @@ impl EppContactInfo {
         let contact_info = ContactInfo {
             info: ContactInfoData {
                 xmlns: EPP_CONTACT_XMLNS.to_string(),
-                id: id.to_string_value(),
+                id: id.into(),
                 auth_info: ContactAuthInfo::new(auth_password),
             },
         };

--- a/epp-client/src/epp/request/contact/update.rs
+++ b/epp-client/src/epp/request/contact/update.rs
@@ -3,7 +3,7 @@
 use epp_client_macros::*;
 
 use crate::epp::object::data::{ContactAuthInfo, ContactStatus, Phone, PostalInfo};
-use crate::epp::object::{ElementName, EppObject, StringValue, StringValueTrait};
+use crate::epp::object::{ElementName, EppObject, StringValue};
 use crate::epp::request::Command;
 use crate::epp::response::contact::info::EppContactInfoResponse;
 use crate::epp::xml::EPP_CONTACT_XMLNS;
@@ -122,7 +122,7 @@ impl EppContactUpdate {
         let contact_update = ContactUpdate {
             contact: ContactUpdateData {
                 xmlns: EPP_CONTACT_XMLNS.to_string(),
-                id: id.to_string_value(),
+                id: id.into(),
                 add_statuses: None,
                 remove_statuses: None,
                 change_info: None,
@@ -140,7 +140,7 @@ impl EppContactUpdate {
         auth_password: &str,
     ) {
         self.data.command.contact.change_info = Some(ContactChangeInfo {
-            email: Some(email.to_string_value()),
+            email: Some(email.into()),
             postal_info: Some(postal_info),
             voice: Some(voice),
             auth_info: Some(ContactAuthInfo::new(auth_password)),

--- a/epp-client/src/epp/request/domain/check.rs
+++ b/epp-client/src/epp/request/domain/check.rs
@@ -2,7 +2,7 @@
 
 use epp_client_macros::*;
 
-use crate::epp::object::{ElementName, EppObject, StringValue, StringValueTrait};
+use crate::epp::object::{ElementName, EppObject, StringValue};
 use crate::epp::request::Command;
 use crate::epp::xml::EPP_DOMAIN_XMLNS;
 use serde::{Deserialize, Serialize};
@@ -81,10 +81,7 @@ pub struct DomainCheck {
 impl EppDomainCheck {
     /// Creates a new EppObject for domain check corresponding to the &lt;epp&gt; tag in EPP XML
     pub fn new(domains: Vec<&str>, client_tr_id: &str) -> EppDomainCheck {
-        let domains = domains
-            .iter()
-            .map(|d| d.to_string_value())
-            .collect::<Vec<StringValue>>();
+        let domains = domains.into_iter().map(|d| d.into()).collect();
 
         let domain_check = DomainCheck {
             list: DomainList {

--- a/epp-client/src/epp/request/domain/create.rs
+++ b/epp-client/src/epp/request/domain/create.rs
@@ -5,7 +5,7 @@ use epp_client_macros::*;
 use crate::epp::object::data::{
     DomainAuthInfo, DomainContact, HostAttr, HostAttrList, HostList, HostObjList, Period,
 };
-use crate::epp::object::{ElementName, EppObject, StringValue, StringValueTrait};
+use crate::epp::object::{ElementName, EppObject, StringValue};
 use crate::epp::request::Command;
 use crate::epp::xml::EPP_DOMAIN_XMLNS;
 use serde::{Deserialize, Serialize};
@@ -122,24 +122,21 @@ impl EppDomainCreate {
     pub fn new_with_ns(
         name: &str,
         period: u16,
-        ns: Vec<&str>,
+        ns: &[&str],
         registrant_id: &str,
         auth_password: &str,
         contacts: Vec<DomainContact>,
         client_tr_id: &str,
     ) -> EppDomainCreate {
-        let ns_list = ns
-            .iter()
-            .map(|n| n.to_string_value())
-            .collect::<Vec<StringValue>>();
+        let ns_list = ns.iter().map(|&n| n.into()).collect();
 
         let domain_create = DomainCreate {
             domain: DomainCreateData {
                 xmlns: EPP_DOMAIN_XMLNS.to_string(),
-                name: name.to_string_value(),
+                name: name.into(),
                 period: Period::new(period),
                 ns: Some(HostList::HostObjList(HostObjList { hosts: ns_list })),
-                registrant: Some(registrant_id.to_string_value()),
+                registrant: Some(registrant_id.into()),
                 auth_info: DomainAuthInfo::new(auth_password),
                 contacts: Some(contacts),
             },
@@ -161,10 +158,10 @@ impl EppDomainCreate {
         let domain_create = DomainCreate {
             domain: DomainCreateData {
                 xmlns: EPP_DOMAIN_XMLNS.to_string(),
-                name: name.to_string_value(),
+                name: name.into(),
                 period: Period::new(period),
                 ns: None,
-                registrant: Some(registrant_id.to_string_value()),
+                registrant: Some(registrant_id.into()),
                 auth_info: DomainAuthInfo::new(auth_password),
                 contacts: Some(contacts),
             },
@@ -183,7 +180,7 @@ impl EppDomainCreate {
         let domain_create = DomainCreate {
             domain: DomainCreateData {
                 xmlns: EPP_DOMAIN_XMLNS.to_string(),
-                name: name.to_string_value(),
+                name: name.into(),
                 period: Period::new(period),
                 ns: None,
                 registrant: None,
@@ -209,10 +206,10 @@ impl EppDomainCreate {
         let domain_create = DomainCreate {
             domain: DomainCreateData {
                 xmlns: EPP_DOMAIN_XMLNS.to_string(),
-                name: name.to_string_value(),
+                name: name.into(),
                 period: Period::new(period),
                 ns: Some(HostList::HostAttrList(HostAttrList { hosts: ns })),
-                registrant: Some(registrant_id.to_string_value()),
+                registrant: Some(registrant_id.into()),
                 auth_info: DomainAuthInfo::new(auth_password),
                 contacts: Some(contacts),
             },

--- a/epp-client/src/epp/request/domain/delete.rs
+++ b/epp-client/src/epp/request/domain/delete.rs
@@ -2,7 +2,7 @@
 
 use epp_client_macros::*;
 
-use crate::epp::object::{ElementName, EppObject, StringValue, StringValueTrait};
+use crate::epp::object::{ElementName, EppObject, StringValue};
 use crate::epp::request::Command;
 use crate::epp::xml::EPP_DOMAIN_XMLNS;
 use serde::{Deserialize, Serialize};
@@ -82,7 +82,7 @@ impl EppDomainDelete {
             DomainDelete {
                 domain: DomainDeleteData {
                     xmlns: EPP_DOMAIN_XMLNS.to_string(),
-                    name: name.to_string_value(),
+                    name: name.into(),
                 },
             },
             client_tr_id,

--- a/epp-client/src/epp/request/domain/renew.rs
+++ b/epp-client/src/epp/request/domain/renew.rs
@@ -3,7 +3,7 @@
 use epp_client_macros::*;
 
 use crate::epp::object::data::Period;
-use crate::epp::object::{ElementName, EppObject, StringValue, StringValueTrait};
+use crate::epp::object::{ElementName, EppObject, StringValue};
 use crate::epp::request::Command;
 use crate::epp::xml::EPP_DOMAIN_XMLNS;
 use chrono::NaiveDate;
@@ -96,16 +96,13 @@ impl EppDomainRenew {
         years: u16,
         client_tr_id: &str,
     ) -> EppDomainRenew {
-        let exp_date_str = current_expiry_date
-            .format("%Y-%m-%d")
-            .to_string()
-            .to_string_value();
+        let exp_date_str = current_expiry_date.format("%Y-%m-%d").to_string().into();
 
         EppObject::build(Command::<DomainRenew>::new(
             DomainRenew {
                 domain: DomainRenewData {
                     xmlns: EPP_DOMAIN_XMLNS.to_string(),
-                    name: name.to_string_value(),
+                    name: name.into(),
                     current_expiry_date: exp_date_str,
                     period: Period::new(years),
                 },

--- a/epp-client/src/epp/request/domain/rgp/report.rs
+++ b/epp-client/src/epp/request/domain/rgp/report.rs
@@ -2,7 +2,7 @@
 
 use epp_client_macros::*;
 
-use crate::epp::object::{ElementName, EppObject, StringValue, StringValueTrait};
+use crate::epp::object::{ElementName, EppObject, StringValue};
 use crate::epp::request::domain::update::{DomainChangeInfo, DomainUpdate, DomainUpdateData};
 use crate::epp::request::{CommandWithExtension, Extension};
 use crate::epp::xml::{EPP_DOMAIN_RGP_EXT_XMLNS, EPP_DOMAIN_XMLNS};
@@ -67,7 +67,7 @@ use serde::{Deserialize, Serialize};
 ///         deleted_at,
 ///         restored_at,
 ///         restore_reason,
-///         statements,
+///         &statements,
 ///         other,
 ///         generate_client_tr_id(&client).as_str()
 ///     );
@@ -141,20 +141,17 @@ impl EppDomainRgpRestoreReport {
         deleted_at: DateTime<Utc>,
         restored_at: DateTime<Utc>,
         restore_reason: &str,
-        statements: Vec<&str>,
+        statements: &[&str],
         other: &str,
         client_tr_id: &str,
     ) -> EppDomainRgpRestoreReport {
-        let statements = statements
-            .iter()
-            .map(|s| s.to_string_value())
-            .collect::<Vec<StringValue>>();
+        let statements = statements.iter().map(|&s| s.into()).collect();
 
         let command = CommandWithExtension::<DomainUpdate, RgpRestoreReport> {
             command: DomainUpdate {
                 domain: DomainUpdateData {
                     xmlns: EPP_DOMAIN_XMLNS.to_string(),
-                    name: name.to_string_value(),
+                    name: name.into(),
                     add: None,
                     remove: None,
                     change_info: Some(DomainChangeInfo {
@@ -169,22 +166,22 @@ impl EppDomainRgpRestoreReport {
                     restore: RgpRestoreReportSection {
                         op: "report".to_string(),
                         report: RgpRestoreReportData {
-                            pre_data: pre_data.to_string_value(),
-                            post_data: post_data.to_string_value(),
+                            pre_data: pre_data.into(),
+                            post_data: post_data.into(),
                             deleted_at: deleted_at
                                 .to_rfc3339_opts(SecondsFormat::AutoSi, true)
-                                .to_string_value(),
+                                .into(),
                             restored_at: restored_at
                                 .to_rfc3339_opts(SecondsFormat::AutoSi, true)
-                                .to_string_value(),
-                            restore_reason: restore_reason.to_string_value(),
+                                .into(),
+                            restore_reason: restore_reason.into(),
                             statements,
-                            other: other.to_string_value(),
+                            other: other.into(),
                         },
                     },
                 },
             }),
-            client_tr_id: client_tr_id.to_string_value(),
+            client_tr_id: client_tr_id.into(),
         };
 
         EppObject::build(command)

--- a/epp-client/src/epp/request/domain/rgp/request.rs
+++ b/epp-client/src/epp/request/domain/rgp/request.rs
@@ -2,7 +2,7 @@
 
 use epp_client_macros::*;
 
-use crate::epp::object::{ElementName, EppObject, StringValueTrait};
+use crate::epp::object::{ElementName, EppObject};
 use crate::epp::request::domain::update::{DomainChangeInfo, DomainUpdate, DomainUpdateData};
 use crate::epp::request::{CommandWithExtension, Extension};
 use crate::epp::xml::{EPP_DOMAIN_RGP_EXT_XMLNS, EPP_DOMAIN_XMLNS};
@@ -86,7 +86,7 @@ impl EppDomainRgpRestoreRequest {
             command: DomainUpdate {
                 domain: DomainUpdateData {
                     xmlns: EPP_DOMAIN_XMLNS.to_string(),
-                    name: name.to_string_value(),
+                    name: name.into(),
                     add: None,
                     remove: None,
                     change_info: Some(DomainChangeInfo {
@@ -103,7 +103,7 @@ impl EppDomainRgpRestoreRequest {
                     },
                 },
             }),
-            client_tr_id: client_tr_id.to_string_value(),
+            client_tr_id: client_tr_id.into(),
         };
 
         EppObject::build(command)

--- a/epp-client/src/epp/request/domain/transfer.rs
+++ b/epp-client/src/epp/request/domain/transfer.rs
@@ -3,7 +3,7 @@
 use epp_client_macros::*;
 
 use crate::epp::object::data::{DomainAuthInfo, Period};
-use crate::epp::object::{ElementName, EppObject, StringValue, StringValueTrait};
+use crate::epp::object::{ElementName, EppObject, StringValue};
 use crate::epp::request::Command;
 use crate::epp::xml::EPP_DOMAIN_XMLNS;
 use serde::{Deserialize, Serialize};
@@ -303,7 +303,7 @@ impl EppDomainTransferRequest {
                 operation: "request".to_string(),
                 domain: DomainTransferData {
                     xmlns: EPP_DOMAIN_XMLNS.to_string(),
-                    name: name.to_string_value(),
+                    name: name.into(),
                     period: Some(Period::new(years)),
                     auth_info: Some(DomainAuthInfo::new(auth_password)),
                 },
@@ -326,7 +326,7 @@ impl EppDomainTransferApprove {
                 operation: "approve".to_string(),
                 domain: DomainTransferData {
                     xmlns: EPP_DOMAIN_XMLNS.to_string(),
-                    name: name.to_string_value(),
+                    name: name.into(),
                     period: None,
                     auth_info: None,
                 },
@@ -344,7 +344,7 @@ impl EppDomainTransferCancel {
                 operation: "cancel".to_string(),
                 domain: DomainTransferData {
                     xmlns: EPP_DOMAIN_XMLNS.to_string(),
-                    name: name.to_string_value(),
+                    name: name.into(),
                     period: None,
                     auth_info: None,
                 },
@@ -362,7 +362,7 @@ impl EppDomainTransferReject {
                 operation: "reject".to_string(),
                 domain: DomainTransferData {
                     xmlns: EPP_DOMAIN_XMLNS.to_string(),
-                    name: name.to_string_value(),
+                    name: name.into(),
                     period: None,
                     auth_info: None,
                 },
@@ -380,7 +380,7 @@ impl EppDomainTransferQuery {
                 operation: "query".to_string(),
                 domain: DomainTransferData {
                     xmlns: EPP_DOMAIN_XMLNS.to_string(),
-                    name: name.to_string_value(),
+                    name: name.into(),
                     period: None,
                     auth_info: Some(DomainAuthInfo::new(auth_password)),
                 },

--- a/epp-client/src/epp/request/domain/update.rs
+++ b/epp-client/src/epp/request/domain/update.rs
@@ -3,7 +3,7 @@
 use epp_client_macros::*;
 
 use crate::epp::object::data::{DomainAuthInfo, DomainContact, DomainStatus, HostList};
-use crate::epp::object::{ElementName, EppObject, StringValue, StringValueTrait};
+use crate::epp::object::{ElementName, EppObject, StringValue};
 use crate::epp::request::Command;
 use crate::epp::xml::EPP_DOMAIN_XMLNS;
 use serde::{Deserialize, Serialize};
@@ -146,7 +146,7 @@ impl EppDomainUpdate {
             DomainUpdate {
                 domain: DomainUpdateData {
                     xmlns: EPP_DOMAIN_XMLNS.to_string(),
-                    name: name.to_string_value(),
+                    name: name.into(),
                     add: None,
                     remove: None,
                     change_info: None,

--- a/epp-client/src/epp/request/host/check.rs
+++ b/epp-client/src/epp/request/host/check.rs
@@ -2,7 +2,7 @@
 
 use epp_client_macros::*;
 
-use crate::epp::object::{ElementName, EppObject, StringValue, StringValueTrait};
+use crate::epp::object::{ElementName, EppObject, StringValue};
 use crate::epp::request::Command;
 use crate::epp::xml::EPP_HOST_XMLNS;
 use serde::{Deserialize, Serialize};
@@ -44,7 +44,7 @@ use serde::{Deserialize, Serialize};
 ///
 ///     // Create an EppHostCheck instance
 ///     let host_check = EppHostCheck::new(
-///         vec!["ns1.eppdev-101.com", "ns2.eppdev-101.com"],
+///         &["ns1.eppdev-101.com", "ns2.eppdev-101.com"],
 ///         generate_client_tr_id(&client).as_str()
 ///     );
 ///
@@ -80,11 +80,8 @@ pub struct HostCheck {
 
 impl EppHostCheck {
     /// Creates a new EppObject for host check corresponding to the &lt;epp&gt; tag in EPP XML
-    pub fn new(hosts: Vec<&str>, client_tr_id: &str) -> EppHostCheck {
-        let hosts = hosts
-            .iter()
-            .map(|d| d.to_string_value())
-            .collect::<Vec<StringValue>>();
+    pub fn new(hosts: &[&str], client_tr_id: &str) -> EppHostCheck {
+        let hosts = hosts.iter().map(|&d| d.into()).collect();
 
         let host_check = HostCheck {
             list: HostList {

--- a/epp-client/src/epp/request/host/create.rs
+++ b/epp-client/src/epp/request/host/create.rs
@@ -3,7 +3,7 @@
 use epp_client_macros::*;
 
 use crate::epp::object::data::HostAddr;
-use crate::epp::object::{ElementName, EppObject, StringValue, StringValueTrait};
+use crate::epp::object::{ElementName, EppObject, StringValue};
 use crate::epp::request::Command;
 use crate::epp::xml::EPP_HOST_XMLNS;
 use serde::{Deserialize, Serialize};
@@ -92,7 +92,7 @@ impl EppHostCreate {
         let host_create = HostCreate {
             host: HostCreateData {
                 xmlns: EPP_HOST_XMLNS.to_string(),
-                name: host.to_string_value(),
+                name: host.into(),
                 addresses: Some(addresses),
             },
         };

--- a/epp-client/src/epp/request/host/delete.rs
+++ b/epp-client/src/epp/request/host/delete.rs
@@ -2,7 +2,7 @@
 
 use epp_client_macros::*;
 
-use crate::epp::object::{ElementName, EppObject, StringValue, StringValueTrait};
+use crate::epp::object::{ElementName, EppObject, StringValue};
 use crate::epp::request::Command;
 use crate::epp::xml::EPP_HOST_XMLNS;
 use serde::{Deserialize, Serialize};
@@ -82,7 +82,7 @@ impl EppHostDelete {
             HostDelete {
                 host: HostDeleteData {
                     xmlns: EPP_HOST_XMLNS.to_string(),
-                    name: name.to_string_value(),
+                    name: name.into(),
                 },
             },
             client_tr_id,

--- a/epp-client/src/epp/request/host/info.rs
+++ b/epp-client/src/epp/request/host/info.rs
@@ -2,7 +2,7 @@
 
 use epp_client_macros::*;
 
-use crate::epp::object::{ElementName, EppObject, StringValue, StringValueTrait};
+use crate::epp::object::{ElementName, EppObject, StringValue};
 use crate::epp::request::Command;
 use crate::epp::xml::EPP_HOST_XMLNS;
 use serde::{Deserialize, Serialize};
@@ -82,7 +82,7 @@ impl EppHostInfo {
             HostInfo {
                 info: HostInfoData {
                     xmlns: EPP_HOST_XMLNS.to_string(),
-                    name: name.to_string_value(),
+                    name: name.into(),
                 },
             },
             client_tr_id,

--- a/epp-client/src/epp/request/host/update.rs
+++ b/epp-client/src/epp/request/host/update.rs
@@ -3,7 +3,7 @@
 use epp_client_macros::*;
 
 use crate::epp::object::data::{HostAddr, HostStatus};
-use crate::epp::object::{ElementName, EppObject, StringValue, StringValueTrait};
+use crate::epp::object::{ElementName, EppObject, StringValue};
 use crate::epp::request::Command;
 use crate::epp::xml::EPP_HOST_XMLNS;
 use serde::{Deserialize, Serialize};
@@ -17,7 +17,6 @@ use serde::{Deserialize, Serialize};
 ///
 /// use epp_client::config::{EppClientConfig, EppClientConnection};
 /// use epp_client::EppClient;
-/// use epp_client::epp::object::StringValueTrait;
 /// use epp_client::epp::object::data::{HostAddr, HostStatus};
 /// use epp_client::epp::{EppHostUpdate, EppHostUpdateResponse, HostAddRemove, HostChangeInfo};
 /// use epp_client::epp::generate_client_tr_id;
@@ -67,7 +66,7 @@ use serde::{Deserialize, Serialize};
 ///     host_update.remove(remove);
 ///
 ///     // Send a &lt;chg&gt; section as well
-///     host_update.info(HostChangeInfo { name: "ns2.eppdev-101.com".to_string_value() });
+///     host_update.info(HostChangeInfo { name: "ns2.eppdev-101.com".into() });
 ///
 ///     // send it to the registry and receive a response of type EppHostUpdateResponse
 ///     let response = client.transact::<_, EppHostUpdateResponse>(&host_update).await.unwrap();
@@ -134,7 +133,7 @@ impl EppHostUpdate {
             HostUpdate {
                 host: HostUpdateData {
                     xmlns: EPP_HOST_XMLNS.to_string(),
-                    name: name.to_string_value(),
+                    name: name.into(),
                     add: None,
                     remove: None,
                     change_info: None,

--- a/epp-client/src/tests/de.rs
+++ b/epp-client/src/tests/de.rs
@@ -3,7 +3,6 @@
 mod response {
     use super::super::get_xml;
     use super::super::CLTRID;
-    use crate::epp::object::StringValueTrait;
     use crate::epp::response::ExpiryType;
     use crate::epp::response::Relative;
     use crate::epp::response::{
@@ -22,11 +21,8 @@ mod response {
 
         assert_eq!(object.data.service_id, "ISPAPI EPP Server");
         assert_eq!(object.data.service_date, "2021-07-25T14:51:17.0Z");
-        assert_eq!(
-            object.data.svc_menu.options.version,
-            "1.0".to_string_value()
-        );
-        assert_eq!(object.data.svc_menu.options.lang, "en".to_string_value());
+        assert_eq!(object.data.svc_menu.options.version, "1.0".into());
+        assert_eq!(object.data.svc_menu.options.lang, "en".into());
         assert_eq!(object.data.svc_menu.services.obj_uris.len(), 4);
         assert_eq!(
             object
@@ -44,7 +40,7 @@ mod response {
         assert_eq!(
             object.data.dcp.expiry.unwrap().ty,
             ExpiryType::Relative(Relative {
-                relative: "P1M".to_string_value()
+                relative: "P1M".into()
             })
         );
     }
@@ -55,19 +51,13 @@ mod response {
         let object = EppCommandResponseError::deserialize(xml.as_str()).unwrap();
 
         assert_eq!(object.data.result.code, 2303);
-        assert_eq!(
-            object.data.result.message,
-            "Object does not exist".to_string_value()
-        );
+        assert_eq!(object.data.result.message, "Object does not exist".into());
         assert_eq!(
             object.data.result.ext_value.unwrap().reason,
-            "545 Object not found".to_string_value()
+            "545 Object not found".into()
         );
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -76,12 +66,9 @@ mod response {
         let object = EppLoginResponse::deserialize(xml.as_str()).unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -92,13 +79,10 @@ mod response {
         assert_eq!(object.data.result.code, 1500);
         assert_eq!(
             object.data.result.message,
-            "Command completed successfully; ending session".to_string_value()
+            "Command completed successfully; ending session".into()
         );
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -109,22 +93,19 @@ mod response {
         let results = object.data.res_data().unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
         assert_eq!(
             results.check_data.contact_list[0].contact.id,
-            "eppdev-contact-1".to_string_value()
+            "eppdev-contact-1".into()
         );
         assert_eq!(results.check_data.contact_list[0].contact.available, 0);
         assert_eq!(
             results.check_data.contact_list[1].contact.id,
-            "eppdev-contact-2".to_string_value()
+            "eppdev-contact-2".into()
         );
         assert_eq!(results.check_data.contact_list[1].contact.available, 1);
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -135,17 +116,14 @@ mod response {
         let results = object.data.res_data().unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
-        assert_eq!(results.create_data.id, "eppdev-contact-4".to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
+        assert_eq!(results.create_data.id, "eppdev-contact-4".into());
         assert_eq!(
             results.create_data.created_at,
-            "2021-07-25T16:05:32.0Z".to_string_value()
+            "2021-07-25T16:05:32.0Z".into()
         );
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -154,12 +132,9 @@ mod response {
         let object = EppContactDeleteResponse::deserialize(xml.as_str()).unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -174,71 +149,53 @@ mod response {
         let auth_info = result.info_data.auth_info.as_ref().unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
-        assert_eq!(result.info_data.id, "eppdev-contact-3".to_string_value());
-        assert_eq!(result.info_data.roid, "UNDEF-ROID".to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
+        assert_eq!(result.info_data.id, "eppdev-contact-3".into());
+        assert_eq!(result.info_data.roid, "UNDEF-ROID".into());
         assert_eq!(result.info_data.statuses[0].status, "ok".to_string());
         assert_eq!(result.info_data.postal_info.info_type, "loc".to_string());
-        assert_eq!(
-            result.info_data.postal_info.name,
-            "John Doe".to_string_value()
-        );
+        assert_eq!(result.info_data.postal_info.name, "John Doe".into());
         assert_eq!(
             result.info_data.postal_info.organization,
-            "Acme Widgets".to_string_value()
+            "Acme Widgets".into()
         );
-        assert_eq!(
-            result.info_data.postal_info.address.street[0],
-            "58".to_string_value()
-        );
+        assert_eq!(result.info_data.postal_info.address.street[0], "58".into());
         assert_eq!(
             result.info_data.postal_info.address.street[1],
-            "Orchid Road".to_string_value()
+            "Orchid Road".into()
         );
-        assert_eq!(
-            result.info_data.postal_info.address.city,
-            "Paris".to_string_value()
-        );
+        assert_eq!(result.info_data.postal_info.address.city, "Paris".into());
         assert_eq!(
             result.info_data.postal_info.address.province,
-            "Paris".to_string_value()
+            "Paris".into()
         );
         assert_eq!(
             result.info_data.postal_info.address.postal_code,
-            "392374".to_string_value()
+            "392374".into()
         );
         assert_eq!(
             result.info_data.postal_info.address.country_code,
-            "FR".to_string_value()
+            "FR".into()
         );
         assert_eq!(result.info_data.voice.number, "+33.47237942".to_string());
         assert_eq!(*voice_ext, "123".to_string());
         assert_eq!(fax.number, "+33.86698799".to_string());
         assert_eq!(*fax_ext, "243".to_string());
-        assert_eq!(
-            result.info_data.email,
-            "contact@eppdev.net".to_string_value()
-        );
-        assert_eq!(result.info_data.client_id, "eppdev".to_string_value());
-        assert_eq!(result.info_data.creator_id, "SYSTEM".to_string_value());
-        assert_eq!(
-            result.info_data.created_at,
-            "2021-07-23T13:09:09.0Z".to_string_value()
-        );
+        assert_eq!(result.info_data.email, "contact@eppdev.net".into());
+        assert_eq!(result.info_data.client_id, "eppdev".into());
+        assert_eq!(result.info_data.creator_id, "SYSTEM".into());
+        assert_eq!(result.info_data.created_at, "2021-07-23T13:09:09.0Z".into());
         assert_eq!(
             *(result.info_data.updater_id.as_ref().unwrap()),
-            "SYSTEM".to_string_value()
+            "SYSTEM".into()
         );
         assert_eq!(
             *(result.info_data.updated_at.as_ref().unwrap()),
-            "2021-07-23T13:09:09.0Z".to_string_value()
+            "2021-07-23T13:09:09.0Z".into()
         );
-        assert_eq!((*auth_info).password, "eppdev-387323".to_string_value());
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!((*auth_info).password, "eppdev-387323".into());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -247,12 +204,9 @@ mod response {
         let object = EppContactUpdateResponse::deserialize(xml.as_str()).unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -263,22 +217,19 @@ mod response {
         let result = object.data.res_data().unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
         assert_eq!(
             result.check_data.domain_list[0].domain.name,
-            "eppdev.com".to_string_value()
+            "eppdev.com".into()
         );
         assert_eq!(result.check_data.domain_list[0].domain.available, 1);
         assert_eq!(
             result.check_data.domain_list[1].domain.name,
-            "eppdev.net".to_string_value()
+            "eppdev.net".into()
         );
         assert_eq!(result.check_data.domain_list[1].domain.available, 0);
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -289,21 +240,18 @@ mod response {
         let result = object.data.res_data().unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
-        assert_eq!(result.create_data.name, "eppdev-2.com".to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
+        assert_eq!(result.create_data.name, "eppdev-2.com".into());
         assert_eq!(
             result.create_data.created_at,
-            "2021-07-25T18:11:35.0Z".to_string_value()
+            "2021-07-25T18:11:35.0Z".into()
         );
         assert_eq!(
             result.create_data.expiring_at,
-            "2022-07-25T18:11:34.0Z".to_string_value()
+            "2022-07-25T18:11:34.0Z".into()
         );
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -312,12 +260,9 @@ mod response {
         let object = EppDomainDeleteResponse::deserialize(xml.as_str()).unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -332,21 +277,15 @@ mod response {
         let hosts = result.info_data.hosts.as_ref().unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
-        assert_eq!(result.info_data.name, "eppdev-1.com".to_string_value());
-        assert_eq!(
-            result.info_data.roid,
-            "125899511_DOMAIN_COM-VRSN".to_string_value()
-        );
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
+        assert_eq!(result.info_data.name, "eppdev-1.com".into());
+        assert_eq!(result.info_data.roid, "125899511_DOMAIN_COM-VRSN".into());
         assert_eq!(result.info_data.statuses[0].status, "ok".to_string());
         assert_eq!(
             result.info_data.statuses[1].status,
             "clientTransferProhibited".to_string()
         );
-        assert_eq!(
-            result.info_data.registrant,
-            "eppdev-contact-2".to_string_value()
-        );
+        assert_eq!(result.info_data.registrant, "eppdev-contact-2".into());
         assert_eq!(
             result.info_data.contacts[0].id,
             "eppdev-contact-2".to_string()
@@ -371,31 +310,22 @@ mod response {
             result.info_data.contacts[2].contact_type,
             "billing".to_string()
         );
-        assert_eq!((*ns)[0], "ns1.eppdev-1.com".to_string_value());
-        assert_eq!((*ns)[1], "ns2.eppdev-1.com".to_string_value());
-        assert_eq!((*hosts)[0], "ns1.eppdev-1.com".to_string_value());
-        assert_eq!((*hosts)[1], "ns2.eppdev-1.com".to_string_value());
-        assert_eq!(result.info_data.client_id, "eppdev".to_string_value());
-        assert_eq!(result.info_data.creator_id, "SYSTEM".to_string_value());
-        assert_eq!(
-            result.info_data.created_at,
-            "2021-07-23T15:31:20.0Z".to_string_value()
-        );
-        assert_eq!(result.info_data.updater_id, "SYSTEM".to_string_value());
-        assert_eq!(
-            result.info_data.updated_at,
-            "2021-07-23T15:31:21.0Z".to_string_value()
-        );
+        assert_eq!((*ns)[0], "ns1.eppdev-1.com".into());
+        assert_eq!((*ns)[1], "ns2.eppdev-1.com".into());
+        assert_eq!((*hosts)[0], "ns1.eppdev-1.com".into());
+        assert_eq!((*hosts)[1], "ns2.eppdev-1.com".into());
+        assert_eq!(result.info_data.client_id, "eppdev".into());
+        assert_eq!(result.info_data.creator_id, "SYSTEM".into());
+        assert_eq!(result.info_data.created_at, "2021-07-23T15:31:20.0Z".into());
+        assert_eq!(result.info_data.updater_id, "SYSTEM".into());
+        assert_eq!(result.info_data.updated_at, "2021-07-23T15:31:21.0Z".into());
         assert_eq!(
             result.info_data.expiring_at,
-            "2023-07-23T15:31:20.0Z".to_string_value()
+            "2023-07-23T15:31:20.0Z".into()
         );
-        assert_eq!((*auth_info).password, "epP4uthd#v".to_string_value());
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!((*auth_info).password, "epP4uthd#v".into());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -406,17 +336,14 @@ mod response {
         let result = object.data.res_data().unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
-        assert_eq!(result.renew_data.name, "eppdev-1.com".to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
+        assert_eq!(result.renew_data.name, "eppdev-1.com".into());
         assert_eq!(
             result.renew_data.expiring_at,
-            "2024-07-23T15:31:20.0Z".to_string_value()
+            "2024-07-23T15:31:20.0Z".into()
         );
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -429,38 +356,23 @@ mod response {
         assert_eq!(object.data.result.code, 1001);
         assert_eq!(
             object.data.result.message,
-            "Command completed successfully; action pending".to_string_value()
+            "Command completed successfully; action pending".into()
         );
-        assert_eq!(
-            result.transfer_data.name,
-            "eppdev-transfer.com".to_string_value()
-        );
-        assert_eq!(
-            result.transfer_data.transfer_status,
-            "pending".to_string_value()
-        );
-        assert_eq!(
-            result.transfer_data.requester_id,
-            "eppdev".to_string_value()
-        );
+        assert_eq!(result.transfer_data.name, "eppdev-transfer.com".into());
+        assert_eq!(result.transfer_data.transfer_status, "pending".into());
+        assert_eq!(result.transfer_data.requester_id, "eppdev".into());
         assert_eq!(
             result.transfer_data.requested_at,
-            "2021-07-23T15:31:21.0Z".to_string_value()
+            "2021-07-23T15:31:21.0Z".into()
         );
-        assert_eq!(result.transfer_data.ack_id, "ClientY".to_string_value());
-        assert_eq!(
-            result.transfer_data.ack_by,
-            "2021-07-28T15:31:21.0Z".to_string_value()
-        );
+        assert_eq!(result.transfer_data.ack_id, "ClientY".into());
+        assert_eq!(result.transfer_data.ack_by, "2021-07-28T15:31:21.0Z".into());
         assert_eq!(
             result.transfer_data.expiring_at,
-            "2022-07-02T14:53:19.0Z".to_string_value()
+            "2022-07-02T14:53:19.0Z".into()
         );
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -469,12 +381,9 @@ mod response {
         let object = EppDomainTransferApproveResponse::deserialize(xml.as_str()).unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -483,12 +392,9 @@ mod response {
         let object = EppDomainTransferRejectResponse::deserialize(xml.as_str()).unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -497,12 +403,9 @@ mod response {
         let object = EppDomainTransferCancelResponse::deserialize(xml.as_str()).unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -513,37 +416,22 @@ mod response {
         let result = object.data.res_data().unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
-        assert_eq!(
-            result.transfer_data.name,
-            "eppdev-transfer.com".to_string_value()
-        );
-        assert_eq!(
-            result.transfer_data.transfer_status,
-            "pending".to_string_value()
-        );
-        assert_eq!(
-            result.transfer_data.requester_id,
-            "eppdev".to_string_value()
-        );
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
+        assert_eq!(result.transfer_data.name, "eppdev-transfer.com".into());
+        assert_eq!(result.transfer_data.transfer_status, "pending".into());
+        assert_eq!(result.transfer_data.requester_id, "eppdev".into());
         assert_eq!(
             result.transfer_data.requested_at,
-            "2021-07-23T15:31:21.0Z".to_string_value()
+            "2021-07-23T15:31:21.0Z".into()
         );
-        assert_eq!(result.transfer_data.ack_id, "ClientY".to_string_value());
-        assert_eq!(
-            result.transfer_data.ack_by,
-            "2021-07-28T15:31:21.0Z".to_string_value()
-        );
+        assert_eq!(result.transfer_data.ack_id, "ClientY".into());
+        assert_eq!(result.transfer_data.ack_by, "2021-07-28T15:31:21.0Z".into());
         assert_eq!(
             result.transfer_data.expiring_at,
-            "2022-07-02T14:53:19.0Z".to_string_value()
+            "2022-07-02T14:53:19.0Z".into()
         );
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -552,12 +440,9 @@ mod response {
         let object = EppDomainUpdateResponse::deserialize(xml.as_str()).unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -568,22 +453,19 @@ mod response {
         let result = object.data.res_data().unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
         assert_eq!(
             result.check_data.host_list[0].host.name,
-            "host1.eppdev-1.com".to_string_value()
+            "host1.eppdev-1.com".into()
         );
         assert_eq!(result.check_data.host_list[0].host.available, 1);
         assert_eq!(
             result.check_data.host_list[1].host.name,
-            "ns1.testing.com".to_string_value()
+            "ns1.testing.com".into()
         );
         assert_eq!(result.check_data.host_list[1].host.available, 0);
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -594,20 +476,14 @@ mod response {
         let result = object.data.res_data().unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
-        assert_eq!(
-            result.create_data.name,
-            "host2.eppdev-1.com".to_string_value()
-        );
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
+        assert_eq!(result.create_data.name, "host2.eppdev-1.com".into());
         assert_eq!(
             result.create_data.created_at,
-            "2021-07-26T05:28:55.0Z".to_string_value()
+            "2021-07-26T05:28:55.0Z".into()
         );
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -618,12 +494,9 @@ mod response {
         let result = object.data.res_data().unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
-        assert_eq!(
-            result.info_data.name,
-            "host2.eppdev-1.com".to_string_value()
-        );
-        assert_eq!(result.info_data.roid, "UNDEF-ROID".to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
+        assert_eq!(result.info_data.name, "host2.eppdev-1.com".into());
+        assert_eq!(result.info_data.roid, "UNDEF-ROID".into());
         assert_eq!(result.info_data.statuses[0].status, "ok".to_string());
         assert_eq!(
             *(result.info_data.addresses[0].ip_version.as_ref().unwrap()),
@@ -641,25 +514,19 @@ mod response {
             result.info_data.addresses[1].address,
             "2404:6800:4001:0801:0000:0000:0000:200e".to_string()
         );
-        assert_eq!(result.info_data.client_id, "eppdev".to_string_value());
-        assert_eq!(result.info_data.creator_id, "creator".to_string_value());
-        assert_eq!(
-            result.info_data.created_at,
-            "2021-07-26T05:28:55.0Z".to_string_value()
-        );
+        assert_eq!(result.info_data.client_id, "eppdev".into());
+        assert_eq!(result.info_data.creator_id, "creator".into());
+        assert_eq!(result.info_data.created_at, "2021-07-26T05:28:55.0Z".into());
         assert_eq!(
             *(result.info_data.updater_id.as_ref().unwrap()),
-            "creator".to_string_value()
+            "creator".into()
         );
         assert_eq!(
             *(result.info_data.updated_at.as_ref().unwrap()),
-            "2021-07-26T05:28:55.0Z".to_string_value()
+            "2021-07-26T05:28:55.0Z".into()
         );
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -668,12 +535,9 @@ mod response {
         let object = EppHostUpdateResponse::deserialize(xml.as_str()).unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -682,12 +546,9 @@ mod response {
         let object = EppHostDeleteResponse::deserialize(xml.as_str()).unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -701,45 +562,33 @@ mod response {
         assert_eq!(object.data.result.code, 1301);
         assert_eq!(
             object.data.result.message,
-            "Command completed successfully; ack to dequeue".to_string_value()
+            "Command completed successfully; ack to dequeue".into()
         );
         assert_eq!(msg.count, 5);
         assert_eq!(msg.id, "12345".to_string());
         assert_eq!(
             *(msg.date.as_ref().unwrap()),
-            "2021-07-23T19:12:43.0Z".to_string_value()
+            "2021-07-23T19:12:43.0Z".into()
         );
         assert_eq!(
             *(msg.message.as_ref().unwrap()),
-            "Transfer requested.".to_string_value()
+            "Transfer requested.".into()
         );
-        assert_eq!(
-            result.message_data.name,
-            "eppdev-transfer.com".to_string_value()
-        );
-        assert_eq!(
-            result.message_data.transfer_status,
-            "pending".to_string_value()
-        );
-        assert_eq!(result.message_data.requester_id, "eppdev".to_string_value());
+        assert_eq!(result.message_data.name, "eppdev-transfer.com".into());
+        assert_eq!(result.message_data.transfer_status, "pending".into());
+        assert_eq!(result.message_data.requester_id, "eppdev".into());
         assert_eq!(
             result.message_data.requested_at,
-            "2021-07-23T15:31:21.0Z".to_string_value()
+            "2021-07-23T15:31:21.0Z".into()
         );
-        assert_eq!(result.message_data.ack_id, "ClientY".to_string_value());
-        assert_eq!(
-            result.message_data.ack_by,
-            "2021-07-28T15:31:21.0Z".to_string_value()
-        );
+        assert_eq!(result.message_data.ack_id, "ClientY".into());
+        assert_eq!(result.message_data.ack_by, "2021-07-28T15:31:21.0Z".into());
         assert_eq!(
             result.message_data.expiring_at,
-            "2022-07-02T14:53:19.0Z".to_string_value()
+            "2022-07-02T14:53:19.0Z".into()
         );
-        assert_eq!(
-            object.data.tr_ids.client_tr_id.unwrap(),
-            CLTRID.to_string_value()
-        );
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.tr_ids.client_tr_id.unwrap(), CLTRID.into());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -750,10 +599,10 @@ mod response {
         let msg = object.data.message_queue().unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
         assert_eq!(msg.count, 4);
         assert_eq!(msg.id, "12345".to_string());
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 
     #[test]
@@ -764,8 +613,8 @@ mod response {
         let ext = object.data.extension.unwrap();
 
         assert_eq!(object.data.result.code, 1000);
-        assert_eq!(object.data.result.message, SUCCESS_MSG.to_string_value());
+        assert_eq!(object.data.result.message, SUCCESS_MSG.into());
         assert_eq!(ext.data.rgp_status.status, "pendingRestore".to_string());
-        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.to_string_value());
+        assert_eq!(object.data.tr_ids.server_tr_id, SVTRID.into());
     }
 }

--- a/epp-client/src/tests/se.rs
+++ b/epp-client/src/tests/se.rs
@@ -7,7 +7,6 @@ mod request {
         Address, ContactStatus, DomainAuthInfo, DomainContact, DomainStatus, HostAddr, HostAttr,
         HostStatus, Phone, PostalInfo,
     };
-    use crate::epp::object::StringValueTrait;
     use crate::epp::request::{EppHello, EppLogin, EppLogout};
     use crate::epp::xml::EppXml;
     use crate::epp::*;
@@ -48,7 +47,7 @@ mod request {
     #[test]
     fn contact_check() {
         let xml = get_xml("request/contact/check.xml").unwrap();
-        let object = EppContactCheck::new(vec!["eppdev-contact-1", "eppdev-contact-2"], CLTRID);
+        let object = EppContactCheck::new(&["eppdev-contact-1", "eppdev-contact-2"], CLTRID);
         let serialized = object.serialize().unwrap();
 
         assert_eq!(xml, serialized);
@@ -58,7 +57,7 @@ mod request {
     fn contact_create() {
         let xml = get_xml("request/contact/create.xml").unwrap();
 
-        let street = vec!["58", "Orchid Road"];
+        let street = &["58", "Orchid Road"];
         let address = Address::new(street, "Paris", "Paris", "392374", "FR");
         let postal_info = PostalInfo::new("int", "John Doe", "Acme Widgets", address);
         let mut voice = Phone::new("+33.47237942");
@@ -98,7 +97,7 @@ mod request {
 
         let mut object = EppContactUpdate::new("eppdev-contact-3", CLTRID);
 
-        let street = vec!["58", "Orchid Road"];
+        let street = &["58", "Orchid Road"];
         let address = Address::new(street, "Paris", "Paris", "392374", "FR");
         let postal_info = PostalInfo::new("loc", "John Doe", "Acme Widgets", address);
         let voice = Phone::new("+33.47237942");
@@ -195,7 +194,7 @@ mod request {
         let object = EppDomainCreate::new_with_ns(
             "eppdev-1.com",
             1,
-            vec!["ns1.test.com", "ns2.test.com"],
+            &["ns1.test.com", "ns2.test.com"],
             "eppdev-contact-3",
             "epP4uthd#v",
             contacts,
@@ -228,11 +227,11 @@ mod request {
 
         let host_attr = vec![
             HostAttr {
-                name: "ns1.eppdev-1.com".to_string_value(),
+                name: "ns1.eppdev-1.com".into(),
                 addresses: None,
             },
             HostAttr {
-                name: "ns2.eppdev-1.com".to_string_value(),
+                name: "ns2.eppdev-1.com".into(),
                 addresses: Some(vec![
                     HostAddr::new_v4("177.232.12.58"),
                     HostAddr::new_v6("2404:6800:4001:801::200e"),
@@ -385,7 +384,7 @@ mod request {
     fn host_check() {
         let xml = get_xml("request/host/check.xml").unwrap();
 
-        let object = EppHostCheck::new(vec!["ns1.eppdev-1.com", "host1.eppdev-1.com"], CLTRID);
+        let object = EppHostCheck::new(&["ns1.eppdev-1.com", "host1.eppdev-1.com"], CLTRID);
 
         let serialized = object.serialize().unwrap();
 
@@ -442,7 +441,7 @@ mod request {
         object.add(add);
         object.remove(remove);
         object.info(HostChangeInfo {
-            name: "host2.eppdev-1.com".to_string_value(),
+            name: "host2.eppdev-1.com".into(),
         });
 
         let serialized = object.serialize().unwrap();
@@ -505,7 +504,7 @@ mod request {
         let deleted_at = DateTime::from_str("2021-07-10T22:00:00.0Z").unwrap();
         let restored_at = DateTime::from_str("2021-07-20T22:00:00.0Z").unwrap();
         let restore_reason = "Registrant error.";
-        let statements = vec![
+        let statements = &[
             "This registrar has not restored the Registered Name in order to assume the rights to use or sell the Registered Name for itself or for any third party.",
             "The information in this report is true to best of this registrar's knowledge, and this registrar acknowledges that intentionally supplying false information in this report shall constitute an incurable material breach of the Registry-Registrar Agreement.",
         ];


### PR DESCRIPTION
This seems more idiomatic since it relies on well-known conversion
traits from the standard library. It is also more concise.

Also apply some other stylistic changes:

* Take &[T] instead of Vec<T> if the Vec cannot be reused
* Elide type annotations for collect() where unnecessary