### PR TITLE
Make login explicit and refactor generate_client_tr_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ async fn main() {
         Err(e) => panic!("Failed to create EppClient: {}",  e)
     };
 
-    let login = Login::<NoExtension>::new("username", "password", &None);
+    let login = Login::<NoExtension>::new("username", "password", None);
     client.transact(login, "transaction-id").await.unwrap();
 
     // Create an DomainCheck instance

--- a/epp-client/README.md
+++ b/epp-client/README.md
@@ -80,7 +80,7 @@ async fn main() {
         Err(e) => panic!("Failed to create EppClient: {}",  e)
     };
 
-    let login = Login::<NoExtension>::new("username", "password", &None);
+    let login = Login::<NoExtension>::new("username", "password", None);
     client.transact(login, "transaction-id").await.unwrap();
 
     // Create an DomainCheck instance

--- a/epp-client/src/client.rs
+++ b/epp-client/src/client.rs
@@ -8,7 +8,6 @@
 //! use epp_client::config::{EppClientConfig, RegistryConfig};
 //! use epp_client::EppClient;
 //! use epp_client::domain::check::DomainCheck;
-//! use epp_client::generate_client_tr_id;
 //! use epp_client::common::NoExtension;
 //!
 //! #[tokio::main]
@@ -21,9 +20,6 @@
 //!     RegistryConfig {
 //!         host: "example.com".to_owned(),
 //!         port: 700,
-//!         username: "username".to_owned(),
-//!         password: "password".to_owned(),
-//!         ext_uris: None,
 //!         tls_files: None,
 //!     },
 //! );
@@ -41,43 +37,28 @@
 //!
 //! // Execute an EPP Command against the registry with distinct request and response objects
 //! let domain_check = DomainCheck::<NoExtension>::new(vec!["eppdev.com", "eppdev.net"]);
-//! let response = client.transact(domain_check, generate_client_tr_id(&client).as_str()).await.unwrap();
+//! let response = client.transact(domain_check, "transaction-id").await.unwrap();
 //! println!("{:?}", response);
 //!
 //! }
 //! ```
 
-use std::time::SystemTime;
 use std::{error::Error, fmt::Debug};
 
-use crate::common::{EppObject, NoExtension};
+use crate::common::EppObject;
 use crate::config::EppClientConfig;
 use crate::error;
 use crate::hello::{Greeting, Hello};
-use crate::login::Login;
-use crate::logout::Logout;
 use crate::registry::{epp_connect, EppConnection};
-use crate::request::{generate_client_tr_id, EppExtension, EppRequest};
-use crate::response::{Response, ResponseStatus};
+use crate::request::{EppExtension, EppRequest};
+use crate::response::Response;
 use crate::xml::EppXml;
 
 /// Instances of the EppClient type are used to transact with the registry.
 /// Once initialized, the EppClient instance can serialize EPP requests to XML and send them
 /// to the registry and deserialize the XML responses from the registry to local types
 pub struct EppClient {
-    credentials: (String, String),
-    ext_uris: Option<Vec<String>>,
     connection: EppConnection,
-}
-
-/// A function to generate a simple client TRID. Should only be used for testing, library users
-/// should generate a client TRID according to their own requirements
-pub fn default_client_tr_id_fn(client: &EppClient) -> String {
-    let timestamp = match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-        Ok(time) => time,
-        Err(e) => panic!("Error in client TRID gen function: {}", e),
-    };
-    format!("{}:{}", &client.username(), timestamp.as_secs())
 }
 
 impl EppClient {
@@ -93,43 +74,12 @@ impl EppClient {
         };
 
         let stream = epp_connect(registry_creds).await?;
-        let credentials = registry_creds.credentials();
-        let ext_uris = registry_creds.ext_uris();
-
-        let ext_uris =
-            ext_uris.map(|uris| uris.iter().map(|u| u.to_string()).collect::<Vec<String>>());
-
         let connection = EppConnection::new(registry.to_string(), stream).await?;
-        EppClient::build(connection, credentials, ext_uris).await
+
+        Ok(EppClient { connection })
     }
 
-    /// Makes a login request to the registry and initializes an EppClient instance with it
-    async fn build(
-        connection: EppConnection,
-        credentials: (String, String),
-        ext_uris: Option<Vec<String>>,
-    ) -> Result<EppClient, Box<dyn Error>> {
-        let mut client = EppClient {
-            connection,
-            credentials,
-            ext_uris,
-        };
-
-        let client_tr_id = generate_client_tr_id(&client.credentials.0)?;
-        let login_request = Login::<NoExtension>::new(
-            &client.credentials.0,
-            &client.credentials.1,
-            &client.ext_uris,
-        );
-
-        client
-            .transact(login_request, client_tr_id.as_str())
-            .await?;
-
-        Ok(client)
-    }
-
-    /// Executes an EPP Hello call and returns the response as an `EppGreeting`
+    /// Executes an EPP Hello call and returns the response as an `Greeting`
     pub async fn hello(&mut self) -> Result<Greeting, Box<dyn Error>> {
         let hello_xml = EppObject::<Hello>::build(Hello).serialize()?;
 
@@ -154,11 +104,6 @@ impl EppClient {
         T::deserialize_response(&response)
     }
 
-    /// Fetches the username used in the registry connection
-    pub fn username(&self) -> String {
-        self.credentials.0.to_string()
-    }
-
     /// Accepts raw EPP XML and returns the raw EPP XML response to it.
     /// Not recommended for direct use but sometimes can be useful for debugging
     pub async fn transact_xml(&mut self, xml: &str) -> Result<String, Box<dyn Error>> {
@@ -170,20 +115,8 @@ impl EppClient {
         String::from(&self.connection.greeting)
     }
 
-    /// Returns the greeting received on establishment of the connection as an `EppGreeting`
+    /// Returns the greeting received on establishment of the connection as an `Greeting`
     pub fn greeting(&self) -> Result<Greeting, error::Error> {
         EppObject::<Greeting>::deserialize(&self.connection.greeting).map(|obj| obj.data)
-    }
-
-    /// Sends the EPP Logout command to log out of the EPP session
-    pub async fn logout(&mut self) -> Result<Response<ResponseStatus, NoExtension>, error::Error> {
-        let client_tr_id = generate_client_tr_id(&self.credentials.0).unwrap();
-        let epp_logout = Logout::<NoExtension>::new();
-
-        let response = self.transact(epp_logout, client_tr_id.as_str()).await?;
-
-        self.connection.shutdown().await?;
-
-        Ok(response)
     }
 }

--- a/epp-client/src/config.rs
+++ b/epp-client/src/config.rs
@@ -16,9 +16,6 @@
 //!     RegistryConfig {
 //!         host: "example.com".to_owned(),
 //!         port: 700,
-//!         username: "username".to_owned(),
-//!         password: "password".to_owned(),
-//!         ext_uris: None,
 //!         tls_files: None,
 //!     },
 //! );
@@ -26,12 +23,6 @@
 //!
 //! // Get configuration for the relevant registry section
 //! let registry = config.registry("verisign").unwrap();
-//!
-//! // Get username and password
-//! let credentials = registry.credentials();
-//!
-//! // Get EPP service extensions
-//! let service_extensions = registry.ext_uris().unwrap();
 //! ```
 
 use std::collections::HashMap;
@@ -63,19 +54,5 @@ impl EppClientConfig {
 pub struct RegistryConfig {
     pub host: String,
     pub port: u16,
-    pub username: String,
-    pub password: String,
-    pub ext_uris: Option<Vec<String>>,
     pub tls_files: Option<EppClientTlsFiles>,
-}
-
-impl RegistryConfig {
-    /// Returns the EPP username and password as a tuple
-    pub fn credentials(&self) -> (String, String) {
-        (self.username.to_string(), self.password.to_string())
-    }
-    /// Returns the service extension URIs to be set in the connection to the registry
-    pub fn ext_uris(&self) -> Option<&Vec<String>> {
-        self.ext_uris.as_ref()
-    }
 }

--- a/epp-client/src/contact/check.rs
+++ b/epp-client/src/contact/check.rs
@@ -33,8 +33,9 @@ impl<E: EppExtension> EppRequest<E> for ContactCheck<E> {
 /// use epp_client::config::{EppClientConfig, RegistryConfig};
 /// use epp_client::EppClient;
 /// use epp_client::contact::check::ContactCheck;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -45,9 +46,6 @@ impl<E: EppExtension> EppRequest<E> for ContactCheck<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -59,6 +57,9 @@ impl<E: EppExtension> EppRequest<E> for ContactCheck<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
+///
 ///     // Create an ContactCheck instance
 ///     let contact_check = ContactCheck::<NoExtension>::new(
 ///         &["epp-client-c1", "epp-client-c2"]
@@ -66,10 +67,11 @@ impl<E: EppExtension> EppRequest<E> for ContactCheck<E> {
 ///
 ///     // send it to the registry and receive a response of type ContactCheckResponse
 ///
-///     let response = client.transact(contact_check, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(contact_check, "transaction-id").await.unwrap();
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> ContactCheck<E> {

--- a/epp-client/src/contact/check.rs
+++ b/epp-client/src/contact/check.rs
@@ -57,7 +57,7 @@ impl<E: EppExtension> EppRequest<E> for ContactCheck<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an ContactCheck instance

--- a/epp-client/src/contact/create.rs
+++ b/epp-client/src/contact/create.rs
@@ -57,7 +57,7 @@ impl<E: EppExtension> EppRequest<E> for ContactCreate<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create the address, postal_info, voice instances

--- a/epp-client/src/contact/create.rs
+++ b/epp-client/src/contact/create.rs
@@ -33,8 +33,9 @@ impl<E: EppExtension> EppRequest<E> for ContactCreate<E> {
 /// use epp_client::EppClient;
 /// use epp_client::common::{Address, Phone, PostalInfo};
 /// use epp_client::contact::create::ContactCreate;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -45,9 +46,6 @@ impl<E: EppExtension> EppRequest<E> for ContactCreate<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -58,6 +56,9 @@ impl<E: EppExtension> EppRequest<E> for ContactCreate<E> {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
+///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create the address, postal_info, voice instances
 ///     let street = vec!["58", "Orchid Road"];
@@ -79,11 +80,12 @@ impl<E: EppExtension> EppRequest<E> for ContactCreate<E> {
 ///     contact_create.set_fax(fax);
 ///
 ///     // send it to the registry and receive a response of type ContactCreateResponse
-///     let response = client.transact(contact_create, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(contact_create, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> ContactCreate<E> {

--- a/epp-client/src/contact/delete.rs
+++ b/epp-client/src/contact/delete.rs
@@ -57,7 +57,7 @@ impl<E: EppExtension> EppRequest<E> for ContactDelete<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an ContactDelete instance

--- a/epp-client/src/contact/delete.rs
+++ b/epp-client/src/contact/delete.rs
@@ -33,8 +33,9 @@ impl<E: EppExtension> EppRequest<E> for ContactDelete<E> {
 /// use epp_client::config::{EppClientConfig, RegistryConfig};
 /// use epp_client::EppClient;
 /// use epp_client::contact::delete::ContactDelete;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -45,9 +46,6 @@ impl<E: EppExtension> EppRequest<E> for ContactDelete<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -59,17 +57,21 @@ impl<E: EppExtension> EppRequest<E> for ContactDelete<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
+///
 ///     // Create an ContactDelete instance
 ///     let contact_delete = ContactDelete::<NoExtension>::new(
 ///         "eppdev-contact-100"
 ///     );
 ///
 ///     // send it to the registry and receive a response of type ContactDeleteResponse
-///     let response = client.transact(contact_delete, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(contact_delete, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> ContactDelete<E> {

--- a/epp-client/src/contact/info.rs
+++ b/epp-client/src/contact/info.rs
@@ -34,8 +34,9 @@ impl<E: EppExtension> EppRequest<E> for ContactInfo<E> {
 /// use epp_client::config::{EppClientConfig, RegistryConfig};
 /// use epp_client::EppClient;
 /// use epp_client::contact::info::ContactInfo;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -46,9 +47,6 @@ impl<E: EppExtension> EppRequest<E> for ContactInfo<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -60,6 +58,9 @@ impl<E: EppExtension> EppRequest<E> for ContactInfo<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
+///
 ///     // Create an ContactInfo instance
 ///     let contact_info = ContactInfo::<NoExtension>::new(
 ///         "eppdev-contact-100",
@@ -67,11 +68,12 @@ impl<E: EppExtension> EppRequest<E> for ContactInfo<E> {
 ///     );
 ///
 ///     // send it to the registry and receive a response of type ContactInfoResponse
-///     let response = client.transact(contact_info, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(contact_info, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> ContactInfo<E> {

--- a/epp-client/src/contact/info.rs
+++ b/epp-client/src/contact/info.rs
@@ -58,7 +58,7 @@ impl<E: EppExtension> EppRequest<E> for ContactInfo<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an ContactInfo instance

--- a/epp-client/src/contact/update.rs
+++ b/epp-client/src/contact/update.rs
@@ -60,7 +60,7 @@ impl<E: EppExtension> EppRequest<E> for ContactUpdate<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an ContactUpdate instance

--- a/epp-client/src/contact/update.rs
+++ b/epp-client/src/contact/update.rs
@@ -35,9 +35,10 @@ impl<E: EppExtension> EppRequest<E> for ContactUpdate<E> {
 /// use epp_client::config::{EppClientConfig, RegistryConfig};
 /// use epp_client::EppClient;
 /// use epp_client::contact::update::ContactUpdate;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::ContactStatus;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -48,9 +49,6 @@ impl<E: EppExtension> EppRequest<E> for ContactUpdate<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -61,6 +59,9 @@ impl<E: EppExtension> EppRequest<E> for ContactUpdate<E> {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
+///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an ContactUpdate instance
 ///     let mut contact_update = ContactUpdate::<NoExtension>::new(
@@ -76,11 +77,12 @@ impl<E: EppExtension> EppRequest<E> for ContactUpdate<E> {
 ///     contact_update.add(add_statuses);
 ///
 ///     // send it to the registry and receive a response of type ContactUpdateResponse
-///     let response = client.transact(contact_update, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(contact_update, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> ContactUpdate<E> {

--- a/epp-client/src/domain/check.rs
+++ b/epp-client/src/domain/check.rs
@@ -32,8 +32,9 @@ impl<E: EppExtension> EppRequest<E> for DomainCheck<E> {
 /// use epp_client::config::{EppClientConfig, RegistryConfig};
 /// use epp_client::EppClient;
 /// use epp_client::domain::check::DomainCheck;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -44,9 +45,6 @@ impl<E: EppExtension> EppRequest<E> for DomainCheck<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -58,17 +56,21 @@ impl<E: EppExtension> EppRequest<E> for DomainCheck<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
+///
 ///     // Create an DomainCheck instance
 ///     let domain_check = DomainCheck::<NoExtension>::new(
 ///         vec!["eppdev-100.com", "eppdev-100.net"],
 ///     );
 ///
 ///     // send it to the registry and receive a response of type EppDomainCheckResponse
-///     let response = client.transact(domain_check, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(domain_check, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> DomainCheck<E> {

--- a/epp-client/src/domain/check.rs
+++ b/epp-client/src/domain/check.rs
@@ -56,7 +56,7 @@ impl<E: EppExtension> EppRequest<E> for DomainCheck<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an DomainCheck instance

--- a/epp-client/src/domain/create.rs
+++ b/epp-client/src/domain/create.rs
@@ -63,7 +63,7 @@ impl<E: EppExtension> EppRequest<E> for DomainCreate<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     let contacts = vec![

--- a/epp-client/src/domain/create.rs
+++ b/epp-client/src/domain/create.rs
@@ -36,8 +36,9 @@ impl<E: EppExtension> EppRequest<E> for DomainCreate<E> {
 /// use epp_client::EppClient;
 /// use epp_client::common::DomainContact;
 /// use epp_client::domain::create::DomainCreate;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 /// use epp_client::common::HostAttrList;
 /// use epp_client::common::HostList;
 /// use epp_client::common::HostObjList;
@@ -51,9 +52,6 @@ impl<E: EppExtension> EppRequest<E> for DomainCreate<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -64,6 +62,9 @@ impl<E: EppExtension> EppRequest<E> for DomainCreate<E> {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
+///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     let contacts = vec![
 ///         DomainContact {
@@ -94,11 +95,12 @@ impl<E: EppExtension> EppRequest<E> for DomainCreate<E> {
 ///     );
 ///
 ///     // send it to the registry and receive a response of type EppDomainCreateResponse
-///     let response = client.transact(domain_create, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(domain_create, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> DomainCreate<E> {

--- a/epp-client/src/domain/delete.rs
+++ b/epp-client/src/domain/delete.rs
@@ -33,8 +33,9 @@ impl<E: EppExtension> EppRequest<E> for DomainDelete<E> {
 /// use epp_client::config::{EppClientConfig, RegistryConfig};
 /// use epp_client::EppClient;
 /// use epp_client::domain::delete::DomainDelete;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -45,9 +46,6 @@ impl<E: EppExtension> EppRequest<E> for DomainDelete<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -59,15 +57,19 @@ impl<E: EppExtension> EppRequest<E> for DomainDelete<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
+///
 ///     // Create an DomainDelete instance
 ///     let mut domain_delete = DomainDelete::<NoExtension>::new("eppdev-100.com");
 ///
 ///     // send it to the registry and receive a response of type DomainDeleteResponse
-///     let response = client.transact(domain_delete, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(domain_delete, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> DomainDelete<E> {

--- a/epp-client/src/domain/delete.rs
+++ b/epp-client/src/domain/delete.rs
@@ -57,7 +57,7 @@ impl<E: EppExtension> EppRequest<E> for DomainDelete<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an DomainDelete instance

--- a/epp-client/src/domain/info.rs
+++ b/epp-client/src/domain/info.rs
@@ -58,7 +58,7 @@ impl<E: EppExtension> EppRequest<E> for DomainInfo<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an DomainInfo instance

--- a/epp-client/src/domain/info.rs
+++ b/epp-client/src/domain/info.rs
@@ -34,8 +34,9 @@ impl<E: EppExtension> EppRequest<E> for DomainInfo<E> {
 /// use epp_client::config::{EppClientConfig, RegistryConfig};
 /// use epp_client::EppClient;
 /// use epp_client::domain::info::DomainInfo;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -46,9 +47,6 @@ impl<E: EppExtension> EppRequest<E> for DomainInfo<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -60,15 +58,19 @@ impl<E: EppExtension> EppRequest<E> for DomainInfo<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
+///
 ///     // Create an DomainInfo instance
 ///     let domain_info = DomainInfo::<NoExtension>::new("eppdev-100.com");
 ///
 ///     // send it to the registry and receive a response of type DomainInfoResponse
-///     let response = client.transact(domain_info, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(domain_info, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> DomainInfo<E> {

--- a/epp-client/src/domain/renew.rs
+++ b/epp-client/src/domain/renew.rs
@@ -35,8 +35,9 @@ impl<E: EppExtension> EppRequest<E> for DomainRenew<E> {
 /// use epp_client::config::{EppClientConfig, RegistryConfig};
 /// use epp_client::EppClient;
 /// use epp_client::domain::renew::DomainRenew;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -47,9 +48,6 @@ impl<E: EppExtension> EppRequest<E> for DomainRenew<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -61,6 +59,9 @@ impl<E: EppExtension> EppRequest<E> for DomainRenew<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
+///
 ///     // Create a date object to set the current expiry date
 ///     let exp_date = NaiveDate::from_ymd(2022, 7, 27);
 ///
@@ -68,11 +69,12 @@ impl<E: EppExtension> EppRequest<E> for DomainRenew<E> {
 ///     let domain_renew = DomainRenew::<NoExtension>::new("eppdev-100.com", exp_date, 1);
 ///
 ///     // send it to the registry and receive a response of type DomainRenewResponse
-///     let response = client.transact(domain_renew, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(domain_renew, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> DomainRenew<E> {

--- a/epp-client/src/domain/renew.rs
+++ b/epp-client/src/domain/renew.rs
@@ -59,7 +59,7 @@ impl<E: EppExtension> EppRequest<E> for DomainRenew<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create a date object to set the current expiry date

--- a/epp-client/src/domain/transfer.rs
+++ b/epp-client/src/domain/transfer.rs
@@ -117,7 +117,7 @@ impl<E: EppExtension> EppRequest<E> for DomainTransferQuery<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an DomainTransferRequest instance
@@ -192,7 +192,7 @@ impl<E: EppExtension> DomainTransferRequest<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an instance of EppClient, passing the config and the registry you want to connect to
@@ -273,7 +273,7 @@ impl<E: EppExtension> DomainTransferApprove<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an DomainTransferReject instance
@@ -348,7 +348,7 @@ impl<E: EppExtension> DomainTransferReject<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an DomainTransferCancel instance
@@ -423,7 +423,7 @@ impl<E: EppExtension> DomainTransferCancel<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an DomainTransferQuery instance

--- a/epp-client/src/domain/transfer.rs
+++ b/epp-client/src/domain/transfer.rs
@@ -93,8 +93,9 @@ impl<E: EppExtension> EppRequest<E> for DomainTransferQuery<E> {
 /// use epp_client::config::{EppClientConfig, RegistryConfig};
 /// use epp_client::EppClient;
 /// use epp_client::domain::transfer::DomainTransferRequest;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -105,9 +106,6 @@ impl<E: EppExtension> EppRequest<E> for DomainTransferQuery<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -119,17 +117,21 @@ impl<E: EppExtension> EppRequest<E> for DomainTransferQuery<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
+///
 ///     // Create an DomainTransferRequest instance
 ///     let domain_transfer_request = DomainTransferRequest::<NoExtension>::new(
 ///         "eppdev-100.net", 1, "epP4uthd#v"
 ///     );
 ///
 ///     // send it to the registry and receive a response of type DomainTransferRequestResponse
-///     let response = client.transact(domain_transfer_request, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(domain_transfer_request, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> DomainTransferRequest<E> {
@@ -166,8 +168,9 @@ impl<E: EppExtension> DomainTransferRequest<E> {
 /// use epp_client::config::{EppClientConfig, RegistryConfig};
 /// use epp_client::EppClient;
 /// use epp_client::domain::transfer::DomainTransferApprove;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -178,13 +181,19 @@ impl<E: EppExtension> DomainTransferRequest<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
 ///     let config = EppClientConfig { registry };
+///
+///     // Create an instance of EppClient, passing the config and the registry you want to connect to
+///     let mut client = match EppClient::new(&config, "registry_name").await {
+///         Ok(client) => client,
+///         Err(e) => panic!("Failed to create EppClient: {}",  e)
+///     };
+///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an instance of EppClient, passing the config and the registry you want to connect to
 ///     let mut client = match EppClient::new(&config, "registry_name").await {
@@ -198,11 +207,12 @@ impl<E: EppExtension> DomainTransferRequest<E> {
 ///     );
 ///
 ///     // send it to the registry and receive a response of type DomainTransferApproveResponse
-///     let response = client.transact(domain_transfer_approve, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(domain_transfer_approve, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> DomainTransferApprove<E> {
@@ -239,8 +249,9 @@ impl<E: EppExtension> DomainTransferApprove<E> {
 /// use epp_client::config::{EppClientConfig, RegistryConfig};
 /// use epp_client::EppClient;
 /// use epp_client::domain::transfer::DomainTransferReject;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -251,9 +262,6 @@ impl<E: EppExtension> DomainTransferApprove<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -265,17 +273,21 @@ impl<E: EppExtension> DomainTransferApprove<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
+///
 ///     // Create an DomainTransferReject instance
 ///     let domain_transfer_reject = DomainTransferReject::<NoExtension>::new(
 ///         "eppdev-100.net"
 ///     );
 ///
 ///     // send it to the registry and receive a response of type DomainTransferRejectResponse
-///     let response = client.transact(domain_transfer_reject, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(domain_transfer_reject, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> DomainTransferReject<E> {
@@ -312,8 +324,9 @@ impl<E: EppExtension> DomainTransferReject<E> {
 /// use epp_client::config::{EppClientConfig, RegistryConfig};
 /// use epp_client::EppClient;
 /// use epp_client::domain::transfer::DomainTransferCancel;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -324,9 +337,6 @@ impl<E: EppExtension> DomainTransferReject<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -338,17 +348,21 @@ impl<E: EppExtension> DomainTransferReject<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
+///
 ///     // Create an DomainTransferCancel instance
 ///     let domain_transfer_cancel = DomainTransferCancel::<NoExtension>::new(
 ///         "eppdev-100.net"
 ///     );
 ///
 ///     // send it to the registry and receive a response of type DomainTransferCancelResponse
-///     let response = client.transact(domain_transfer_cancel, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(domain_transfer_cancel, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> DomainTransferCancel<E> {
@@ -385,8 +399,9 @@ impl<E: EppExtension> DomainTransferCancel<E> {
 /// use epp_client::config::{EppClientConfig, RegistryConfig};
 /// use epp_client::EppClient;
 /// use epp_client::domain::transfer::DomainTransferQuery;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -397,9 +412,6 @@ impl<E: EppExtension> DomainTransferCancel<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -411,17 +423,21 @@ impl<E: EppExtension> DomainTransferCancel<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
+///
 ///     // Create an DomainTransferQuery instance
 ///     let domain_transfer_query = DomainTransferQuery::<NoExtension>::new(
 ///         "eppdev-100.net", "epP4uthd#v"
 ///     );
 ///
 ///     // send it to the registry and receive a response of type DomainTransferQueryResponse
-///     let response = client.transact(domain_transfer_query, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(domain_transfer_query, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> DomainTransferQuery<E> {

--- a/epp-client/src/domain/update.rs
+++ b/epp-client/src/domain/update.rs
@@ -66,7 +66,7 @@ impl<E: EppExtension> EppRequest<E> for DomainUpdate<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an DomainUpdate instance

--- a/epp-client/src/domain/update.rs
+++ b/epp-client/src/domain/update.rs
@@ -42,8 +42,9 @@ impl<E: EppExtension> EppRequest<E> for DomainUpdate<E> {
 /// use epp_client::EppClient;
 /// use epp_client::common::{DomainStatus, DomainContact};
 /// use epp_client::domain::update::{DomainUpdate, DomainAddRemove};
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -54,9 +55,6 @@ impl<E: EppExtension> EppRequest<E> for DomainUpdate<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -67,6 +65,9 @@ impl<E: EppExtension> EppRequest<E> for DomainUpdate<E> {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
+///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an DomainUpdate instance
 ///     let mut domain_update = DomainUpdate::<NoExtension>::new("eppdev-100.com");
@@ -96,11 +97,12 @@ impl<E: EppExtension> EppRequest<E> for DomainUpdate<E> {
 ///     domain_update.remove(remove);
 ///
 ///     // send it to the registry and receive a response of type EppDomainUpdateResponse
-///     let response = client.transact(domain_update, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(domain_update, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> DomainUpdate<E> {

--- a/epp-client/src/extensions/namestore.rs
+++ b/epp-client/src/extensions/namestore.rs
@@ -20,8 +20,10 @@ pub const XMLNS: &str = "http://www.verisign-grs.com/epp/namestoreExt-1.1";
 /// use epp_client::config::{EppClientConfig, RegistryConfig};
 /// use epp_client::EppClient;
 /// use epp_client::domain::check::DomainCheck;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::extensions::namestore::NameStore;
+/// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -32,9 +34,6 @@ pub const XMLNS: &str = "http://www.verisign-grs.com/epp/namestoreExt-1.1";
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -46,6 +45,9 @@ pub const XMLNS: &str = "http://www.verisign-grs.com/epp/namestoreExt-1.1";
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
+///
 ///     let namestore_ext = NameStore::new("com");
 ///
 ///     // Create an DomainCheck instance
@@ -54,11 +56,12 @@ pub const XMLNS: &str = "http://www.verisign-grs.com/epp/namestoreExt-1.1";
 ///     ).with_extension(namestore_ext);
 ///
 ///     // send it to the registry and receive a response of type EppDomainCheckResponse
-///     let response = client.transact(domain_check, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(domain_check, "test-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl NameStore {

--- a/epp-client/src/extensions/namestore.rs
+++ b/epp-client/src/extensions/namestore.rs
@@ -45,7 +45,7 @@ pub const XMLNS: &str = "http://www.verisign-grs.com/epp/namestoreExt-1.1";
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     let namestore_ext = NameStore::new("com");

--- a/epp-client/src/extensions/rgp/report.rs
+++ b/epp-client/src/extensions/rgp/report.rs
@@ -21,8 +21,9 @@ use super::EPP_DOMAIN_RGP_EXT_XMLNS;
 /// use epp_client::common::{DomainStatus, DomainContact};
 /// use epp_client::extensions::rgp::report::RgpRestoreReport;
 /// use epp_client::domain::update::DomainUpdate;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 /// use chrono::{DateTime, NaiveDate};
 /// use std::str::FromStr;
 ///
@@ -35,9 +36,6 @@ use super::EPP_DOMAIN_RGP_EXT_XMLNS;
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -48,6 +46,9 @@ use super::EPP_DOMAIN_RGP_EXT_XMLNS;
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
+///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     let pre_data =
 ///         "Pre-delete registration data goes here. Both XML and free text are allowed.";
@@ -76,11 +77,12 @@ use super::EPP_DOMAIN_RGP_EXT_XMLNS;
 ///     let mut domain_update = DomainUpdate::<RgpRestoreReport>::new("eppdev-100.com").with_extension(domain_restore_report);
 ///
 ///     // send it to the registry and receive a response of type EppDomainUpdateResponse
-///     let response = client.transact(domain_update, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(domain_update, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl RgpRestoreReport {

--- a/epp-client/src/extensions/rgp/report.rs
+++ b/epp-client/src/extensions/rgp/report.rs
@@ -47,7 +47,7 @@ use super::EPP_DOMAIN_RGP_EXT_XMLNS;
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     let pre_data =

--- a/epp-client/src/extensions/rgp/request.rs
+++ b/epp-client/src/extensions/rgp/request.rs
@@ -45,7 +45,7 @@ use super::EPP_DOMAIN_RGP_EXT_XMLNS;
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an RgpRestoreRequest instance

--- a/epp-client/src/extensions/rgp/request.rs
+++ b/epp-client/src/extensions/rgp/request.rs
@@ -21,7 +21,9 @@ use super::EPP_DOMAIN_RGP_EXT_XMLNS;
 /// use epp_client::EppClient;
 /// use epp_client::extensions::rgp::request::RgpRestoreRequest;
 /// use epp_client::domain::update::DomainUpdate;
-/// use epp_client::generate_client_tr_id;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
+/// use epp_client::common::NoExtension;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -32,9 +34,6 @@ use super::EPP_DOMAIN_RGP_EXT_XMLNS;
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -46,6 +45,9 @@ use super::EPP_DOMAIN_RGP_EXT_XMLNS;
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
+///
 ///     // Create an RgpRestoreRequest instance
 ///     let domain_restore_req = RgpRestoreRequest::new();
 ///
@@ -53,11 +55,12 @@ use super::EPP_DOMAIN_RGP_EXT_XMLNS;
 ///     let mut domain_update = DomainUpdate::<RgpRestoreRequest>::new("eppdev-100.com").with_extension(domain_restore_req);
 ///
 ///     // send it to the registry and receive a response of type EppDomainUpdateResponse
-///     let response = client.transact(domain_update, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(domain_update, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl RgpRestoreRequest {

--- a/epp-client/src/host/check.rs
+++ b/epp-client/src/host/check.rs
@@ -34,8 +34,9 @@ impl<E: EppExtension> EppRequest<E> for HostCheck<E> {
 /// use epp_client::config::{EppClientConfig, RegistryConfig};
 /// use epp_client::EppClient;
 /// use epp_client::host::check::HostCheck;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -46,9 +47,6 @@ impl<E: EppExtension> EppRequest<E> for HostCheck<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -60,17 +58,21 @@ impl<E: EppExtension> EppRequest<E> for HostCheck<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
+///
 ///     // Create an HostCheck instance
 ///     let host_check = HostCheck::<NoExtension>::new(
 ///         &["ns1.eppdev-101.com", "ns2.eppdev-101.com"]
 ///     );
 ///
 ///     // send it to the registry and receive a response of type HostCheckResponse
-///     let response = client.transact(host_check, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(host_check, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> HostCheck<E> {

--- a/epp-client/src/host/check.rs
+++ b/epp-client/src/host/check.rs
@@ -58,7 +58,7 @@ impl<E: EppExtension> EppRequest<E> for HostCheck<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an HostCheck instance

--- a/epp-client/src/host/create.rs
+++ b/epp-client/src/host/create.rs
@@ -57,7 +57,7 @@ impl<E: EppExtension> EppRequest<E> for HostCreate<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create a vector of IP addresses to assign to the host

--- a/epp-client/src/host/create.rs
+++ b/epp-client/src/host/create.rs
@@ -33,8 +33,9 @@ impl<E: EppExtension> EppRequest<E> for HostCreate<E> {
 /// use epp_client::EppClient;
 /// use epp_client::common::HostAddr;
 /// use epp_client::host::create::HostCreate;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -45,9 +46,6 @@ impl<E: EppExtension> EppRequest<E> for HostCreate<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -59,6 +57,9 @@ impl<E: EppExtension> EppRequest<E> for HostCreate<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
+///
 ///     // Create a vector of IP addresses to assign to the host
 ///     let addresses = vec![
 ///         HostAddr::new("v4", "29.245.122.14"),
@@ -69,11 +70,12 @@ impl<E: EppExtension> EppRequest<E> for HostCreate<E> {
 ///     let host_create = HostCreate::<NoExtension>::new("ns1.eppdev-101.com", addresses);
 ///
 ///     // send it to the registry and receive a response of type HostCreateResponse
-///     let response = client.transact(host_create, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(host_create, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> HostCreate<E> {

--- a/epp-client/src/host/delete.rs
+++ b/epp-client/src/host/delete.rs
@@ -57,7 +57,7 @@ impl<E: EppExtension> EppRequest<E> for HostDelete<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an HostDelete instance

--- a/epp-client/src/host/delete.rs
+++ b/epp-client/src/host/delete.rs
@@ -33,8 +33,9 @@ impl<E: EppExtension> EppRequest<E> for HostDelete<E> {
 /// use epp_client::config::{EppClientConfig, RegistryConfig};
 /// use epp_client::EppClient;
 /// use epp_client::host::delete::HostDelete;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -45,9 +46,6 @@ impl<E: EppExtension> EppRequest<E> for HostDelete<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -59,15 +57,19 @@ impl<E: EppExtension> EppRequest<E> for HostDelete<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
+///
 ///     // Create an HostDelete instance
 ///     let host_delete = HostDelete::<NoExtension>::new("ns2.eppdev-101.com");
 ///
 ///     // send it to the registry and receive a response of type HostDeleteResponse
-///     let response = client.transact(host_delete, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(host_delete, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> HostDelete<E> {

--- a/epp-client/src/host/info.rs
+++ b/epp-client/src/host/info.rs
@@ -56,7 +56,7 @@ impl<E: EppExtension> EppRequest<E> for HostInfo<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an HostInfo instance

--- a/epp-client/src/host/info.rs
+++ b/epp-client/src/host/info.rs
@@ -32,8 +32,9 @@ impl<E: EppExtension> EppRequest<E> for HostInfo<E> {
 /// use epp_client::config::{EppClientConfig, RegistryConfig};
 /// use epp_client::EppClient;
 /// use epp_client::host::info::HostInfo;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -44,9 +45,6 @@ impl<E: EppExtension> EppRequest<E> for HostInfo<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -58,15 +56,19 @@ impl<E: EppExtension> EppRequest<E> for HostInfo<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
+///
 ///     // Create an HostInfo instance
 ///     let host_info = HostInfo::<NoExtension>::new("ns2.eppdev-101.com");
 ///
 ///     // send it to the registry and receive a response of type HostInfoResponse
-///     let response = client.transact(host_info, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(host_info, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> HostInfo<E> {

--- a/epp-client/src/host/update.rs
+++ b/epp-client/src/host/update.rs
@@ -34,8 +34,9 @@ impl<E: EppExtension> EppRequest<E> for HostUpdate<E> {
 /// use epp_client::EppClient;
 /// use epp_client::common::{HostAddr, HostStatus};
 /// use epp_client::host::update::{HostUpdate, HostAddRemove, HostChangeInfo};
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -46,9 +47,6 @@ impl<E: EppExtension> EppRequest<E> for HostUpdate<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -59,6 +57,9 @@ impl<E: EppExtension> EppRequest<E> for HostUpdate<E> {
 ///         Ok(client) => client,
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
+///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an HostUpdate instance
 ///     let mut host_update = HostUpdate::<NoExtension>::new("ns1.eppdev-101.com");
@@ -85,11 +86,12 @@ impl<E: EppExtension> EppRequest<E> for HostUpdate<E> {
 ///     host_update.info(HostChangeInfo { name: "ns2.eppdev-101.com".into() });
 ///
 ///     // send it to the registry and receive a response of type HostUpdateResponse
-///     let response = client.transact(host_update, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(host_update, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> HostUpdate<E> {

--- a/epp-client/src/host/update.rs
+++ b/epp-client/src/host/update.rs
@@ -58,7 +58,7 @@ impl<E: EppExtension> EppRequest<E> for HostUpdate<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an HostUpdate instance

--- a/epp-client/src/lib.rs
+++ b/epp-client/src/lib.rs
@@ -44,8 +44,9 @@
 //! use epp_client::config::{EppClientConfig, RegistryConfig};
 //! use epp_client::EppClient;
 //! use epp_client::domain::check::DomainCheck;
-//! use epp_client::generate_client_tr_id;
 //! use epp_client::common::NoExtension;
+//! use epp_client::login::Login;
+//! use epp_client::logout::Logout;
 //!
 //! #[tokio::main]
 //! async fn main() {
@@ -57,9 +58,6 @@
 //!     RegistryConfig {
 //!         host: "example.com".to_owned(),
 //!         port: 700,
-//!         username: "username".to_owned(),
-//!         password: "password".to_owned(),
-//!         ext_uris: None,
 //!         tls_files: None,
 //!     },
 //! );
@@ -71,13 +69,16 @@
 //!     Err(e) => panic!("Failed to create EppClient: {}",  e)
 //! };
 //!
+//! let login = Login::<NoExtension>::new("username", "password", &None);
+//! client.transact(login, "transaction-id").await.unwrap();
+//!
 //! // Make a domain check call, which returns an object of type EppDomainCheckResponse
 //! // that contains the result of the call
 //! let domain_check = DomainCheck::<NoExtension>::new(
 //!     vec!["eppdev.com", "eppdev.net"],
 //! );
 //!
-//! let response = client.transact(domain_check, generate_client_tr_id(&client).as_str()).await.unwrap();
+//! let response = client.transact(domain_check, "transaction-id").await.unwrap();
 //!
 //! // print the availability results
 //! response.res_data.unwrap().check_data.domain_list
@@ -85,8 +86,8 @@
 //!     .for_each(|chk| println!("Domain: {}, Available: {}", chk.domain.name, chk.domain.available));
 //!
 //! // Close the connection
-//! client.logout().await.unwrap();
-//!
+//! let logout = Logout::<NoExtension>::new();
+//! client.transact(logout, "transaction-id").await.unwrap();
 //! }
 //! ```
 //!
@@ -154,7 +155,6 @@ pub mod message {
     pub mod poll;
 }
 
-pub use client::default_client_tr_id_fn as generate_client_tr_id;
 pub use client::EppClient;
 
 #[cfg(test)]

--- a/epp-client/src/lib.rs
+++ b/epp-client/src/lib.rs
@@ -69,7 +69,7 @@
 //!     Err(e) => panic!("Failed to create EppClient: {}",  e)
 //! };
 //!
-//! let login = Login::<NoExtension>::new("username", "password", &None);
+//! let login = Login::<NoExtension>::new("username", "password", None);
 //! client.transact(login, "transaction-id").await.unwrap();
 //!
 //! // Make a domain check call, which returns an object of type EppDomainCheckResponse

--- a/epp-client/src/login.rs
+++ b/epp-client/src/login.rs
@@ -29,11 +29,9 @@ impl<E: EppExtension> Login<E> {
     pub fn new(
         username: &str,
         password: &str,
-        ext_uris: &Option<Vec<String>>,
+        ext_uris: Option<Vec<String>>,
     ) -> Login<NoExtension> {
-        let ext_uris = ext_uris
-            .as_ref()
-            .map(|uris| uris.iter().map(|u| u.as_str().into()).collect());
+        let ext_uris = ext_uris.map(|uris| uris.iter().map(|u| u.as_str().into()).collect());
 
         Login {
             request: LoginRequest {

--- a/epp-client/src/message/ack.rs
+++ b/epp-client/src/message/ack.rs
@@ -54,7 +54,7 @@ impl<E: EppExtension> EppRequest<E> for MessageAck<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an MessageAck instance

--- a/epp-client/src/message/ack.rs
+++ b/epp-client/src/message/ack.rs
@@ -30,8 +30,9 @@ impl<E: EppExtension> EppRequest<E> for MessageAck<E> {
 /// use epp_client::config::{EppClientConfig, RegistryConfig};
 /// use epp_client::EppClient;
 /// use epp_client::message::ack::MessageAck;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -42,9 +43,6 @@ impl<E: EppExtension> EppRequest<E> for MessageAck<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -56,15 +54,19 @@ impl<E: EppExtension> EppRequest<E> for MessageAck<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
+///
 ///     // Create an MessageAck instance
 ///     let message_ack = MessageAck::<NoExtension>::new(12345);
 ///
 ///     // send it to the registry and receive a response of type MessageAckResponse
-///     let response = client.transact(message_ack, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(message_ack, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> MessageAck<E> {

--- a/epp-client/src/message/poll.rs
+++ b/epp-client/src/message/poll.rs
@@ -31,8 +31,9 @@ impl<E: EppExtension> EppRequest<E> for MessagePoll<E> {
 /// use epp_client::config::{EppClientConfig, RegistryConfig};
 /// use epp_client::EppClient;
 /// use epp_client::message::poll::MessagePoll;
-/// use epp_client::generate_client_tr_id;
 /// use epp_client::common::NoExtension;
+/// use epp_client::login::Login;
+/// use epp_client::logout::Logout;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -43,9 +44,6 @@ impl<E: EppExtension> EppRequest<E> for MessagePoll<E> {
 ///         RegistryConfig {
 ///             host: "example.com".to_owned(),
 ///             port: 700,
-///             username: "username".to_owned(),
-///             password: "password".to_owned(),
-///             ext_uris: None,
 ///             tls_files: None,
 ///         },
 ///     );
@@ -57,15 +55,19 @@ impl<E: EppExtension> EppRequest<E> for MessagePoll<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
+///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     client.transact(login, "transaction-id").await.unwrap();
+///
 ///     // Create an MessagePoll instance
 ///     let message_poll = MessagePoll::<NoExtension>::new();
 ///
 ///     // send it to the registry and receive a response of type MessagePollResponse
-///     let response = client.transact(message_poll, generate_client_tr_id(&client).as_str()).await.unwrap();
+///     let response = client.transact(message_poll, "transaction-id").await.unwrap();
 ///
 ///     println!("{:?}", response);
 ///
-///     client.logout().await.unwrap();
+///     let logout = Logout::<NoExtension>::new();
+///     client.transact(logout, "transaction-id").await.unwrap();
 /// }
 /// ```
 impl<E: EppExtension> MessagePoll<E> {

--- a/epp-client/src/message/poll.rs
+++ b/epp-client/src/message/poll.rs
@@ -55,7 +55,7 @@ impl<E: EppExtension> EppRequest<E> for MessagePoll<E> {
 ///         Err(e) => panic!("Failed to create EppClient: {}",  e)
 ///     };
 ///
-///     let login = Login::<NoExtension>::new("username", "password", &None);
+///     let login = Login::<NoExtension>::new("username", "password", None);
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an MessagePoll instance

--- a/epp-client/src/request.rs
+++ b/epp-client/src/request.rs
@@ -1,9 +1,7 @@
 //! Types for EPP requests
 
 use serde::{de::DeserializeOwned, ser::SerializeStruct, ser::Serializer, Deserialize, Serialize};
-use std::error::Error;
 use std::fmt::Debug;
-use std::time::SystemTime;
 
 use crate::{
     common::{ElementName, EppObject, Extension, StringValue},
@@ -86,10 +84,4 @@ impl<T: ElementName, E: ElementName> Command<T, E> {
             client_tr_id: client_tr_id.into(),
         }
     }
-}
-
-/// Basic client TRID generation function. Mainly used for testing. Users of the library should use their own clTRID generation function.
-pub fn generate_client_tr_id(username: &str) -> Result<String, Box<dyn Error>> {
-    let timestamp = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?;
-    Ok(format!("{}:{}", username, timestamp.as_secs()))
 }

--- a/epp-client/src/tests/se.rs
+++ b/epp-client/src/tests/se.rs
@@ -64,7 +64,7 @@ mod request {
         ]);
 
         let xml = get_xml("request/login.xml").unwrap();
-        let object = Login::<NoExtension>::new("username", "password", &ext_uris);
+        let object = Login::<NoExtension>::new("username", "password", ext_uris);
         let serialized = object.serialize_request(CLTRID).unwrap();
 
         assert_eq!(xml, serialized);


### PR DESCRIPTION
What do you think of this change?

This pull request makes the login command explicit instead of implicitly occurring as part of the EppClient constructor. It also moves generate_client_tr_id into a instance method and uses micros instead of secs.