### PR TITLE
Update DomainInfo model to reflect RFC

### DIFF
--- a/epp-client/src/domain/info.rs
+++ b/epp-client/src/domain/info.rs
@@ -62,7 +62,7 @@ impl<E: EppExtension> EppRequest<E> for DomainInfo<E> {
 ///     client.transact(login, "transaction-id").await.unwrap();
 ///
 ///     // Create an DomainInfo instance
-///     let domain_info = DomainInfo::<NoExtension>::new("eppdev-100.com");
+///     let domain_info = DomainInfo::<NoExtension>::new("eppdev-100.com", None);
 ///
 ///     // send it to the registry and receive a response of type DomainInfoResponse
 ///     let response = client.transact(domain_info, "transaction-id").await.unwrap();
@@ -74,7 +74,7 @@ impl<E: EppExtension> EppRequest<E> for DomainInfo<E> {
 /// }
 /// ```
 impl<E: EppExtension> DomainInfo<E> {
-    pub fn new(name: &str) -> DomainInfo<NoExtension> {
+    pub fn new(name: &str, auth_password: Option<&str>) -> DomainInfo<NoExtension> {
         DomainInfo {
             request: DomainInfoRequest {
                 info: DomainInfoRequestData {
@@ -83,6 +83,9 @@ impl<E: EppExtension> DomainInfo<E> {
                         hosts: "all".to_string(),
                         name: name.to_string(),
                     },
+                    auth_info: auth_password.map(|password| DomainAuthInfo {
+                        password: password.into(),
+                    }),
                 },
             },
             extension: None,
@@ -118,6 +121,9 @@ pub struct DomainInfoRequestData {
     /// The data for the domain to be queried
     #[serde(rename = "domain:name", alias = "name")]
     domain: Domain,
+    /// The auth info for the domain
+    #[serde(rename = "domain:authInfo", alias = "authInfo")]
+    auth_info: Option<DomainAuthInfo>,
 }
 
 #[derive(Serialize, Deserialize, Debug, ElementName)]
@@ -154,12 +160,12 @@ pub struct DomainInfoResponseData {
     pub roid: StringValue,
     /// The list of domain statuses
     #[serde(rename = "status")]
-    pub statuses: Vec<DomainStatus>,
+    pub statuses: Option<Vec<DomainStatus>>,
     /// The domain registrant
-    pub registrant: StringValue,
+    pub registrant: Option<StringValue>,
     /// The list of domain contacts
     #[serde(rename = "contact")]
-    pub contacts: Vec<DomainContact>,
+    pub contacts: Option<Vec<DomainContact>>,
     /// The list of domain nameservers
     #[serde(rename = "ns")]
     pub ns: Option<DomainNsList>,
@@ -171,19 +177,19 @@ pub struct DomainInfoResponseData {
     pub client_id: StringValue,
     /// The epp user who created the domain
     #[serde(rename = "crID")]
-    pub creator_id: StringValue,
+    pub creator_id: Option<StringValue>,
     /// The domain creation date
     #[serde(rename = "crDate")]
-    pub created_at: StringValue,
-    /// The epp user who last updated the domain
-    #[serde(rename = "upID")]
-    pub updater_id: StringValue,
-    /// The domain last updated date
-    #[serde(rename = "upDate")]
-    pub updated_at: StringValue,
+    pub created_at: Option<StringValue>,
     /// The domain expiry date
     #[serde(rename = "exDate")]
-    pub expiring_at: StringValue,
+    pub expiring_at: Option<StringValue>,
+    /// The epp user who last updated the domain
+    #[serde(rename = "upID")]
+    pub updater_id: Option<StringValue>,
+    /// The domain last updated date
+    #[serde(rename = "upDate")]
+    pub updated_at: Option<StringValue>,
     /// The domain transfer date
     #[serde(rename = "trDate")]
     pub transferred_at: Option<StringValue>,

--- a/epp-client/src/tests/de.rs
+++ b/epp-client/src/tests/de.rs
@@ -299,57 +299,57 @@ mod response {
         let ns_list = result.info_data.ns.as_ref().unwrap();
         let ns = (*ns_list).host_obj.as_ref().unwrap();
         let hosts = result.info_data.hosts.as_ref().unwrap();
+        let statuses = result.info_data.statuses.as_ref().unwrap();
+        let registrant = result.info_data.registrant.as_ref().unwrap();
+        let contacts = result.info_data.contacts.as_ref().unwrap();
 
         assert_eq!(object.result.code, 1000);
         assert_eq!(object.result.message, SUCCESS_MSG.into());
         assert_eq!(result.info_data.name, "eppdev-1.com".into());
         assert_eq!(result.info_data.roid, "125899511_DOMAIN_COM-VRSN".into());
-        assert_eq!(result.info_data.statuses[0].status, "ok".to_string());
-        assert_eq!(
-            result.info_data.statuses[1].status,
-            "clientTransferProhibited".to_string()
-        );
-        assert_eq!(result.info_data.registrant, "eppdev-contact-2".into());
-        assert_eq!(
-            result.info_data.contacts[0].id,
-            "eppdev-contact-2".to_string()
-        );
-        assert_eq!(
-            result.info_data.contacts[0].contact_type,
-            "admin".to_string()
-        );
-        assert_eq!(
-            result.info_data.contacts[1].id,
-            "eppdev-contact-2".to_string()
-        );
-        assert_eq!(
-            result.info_data.contacts[1].contact_type,
-            "tech".to_string()
-        );
-        assert_eq!(
-            result.info_data.contacts[2].id,
-            "eppdev-contact-2".to_string()
-        );
-        assert_eq!(
-            result.info_data.contacts[2].contact_type,
-            "billing".to_string()
-        );
+        assert_eq!(statuses[0].status, "ok".to_string());
+        assert_eq!(statuses[1].status, "clientTransferProhibited".to_string());
+        assert_eq!(*registrant, "eppdev-contact-2".into());
+        assert_eq!(contacts[0].id, "eppdev-contact-2".to_string());
+        assert_eq!(contacts[0].contact_type, "admin".to_string());
+        assert_eq!(contacts[1].id, "eppdev-contact-2".to_string());
+        assert_eq!(contacts[1].contact_type, "tech".to_string());
+        assert_eq!(contacts[2].id, "eppdev-contact-2".to_string());
+        assert_eq!(contacts[2].contact_type, "billing".to_string());
         assert_eq!((*ns)[0], "ns1.eppdev-1.com".into());
         assert_eq!((*ns)[1], "ns2.eppdev-1.com".into());
         assert_eq!((*hosts)[0], "ns1.eppdev-1.com".into());
         assert_eq!((*hosts)[1], "ns2.eppdev-1.com".into());
         assert_eq!(result.info_data.client_id, "eppdev".into());
-        assert_eq!(result.info_data.creator_id, "SYSTEM".into());
-        assert_eq!(result.info_data.created_at, "2021-07-23T15:31:20.0Z".into());
-        assert_eq!(result.info_data.updater_id, "SYSTEM".into());
-        assert_eq!(result.info_data.updated_at, "2021-07-23T15:31:21.0Z".into());
         assert_eq!(
-            result.info_data.expiring_at,
+            *result.info_data.creator_id.as_ref().unwrap(),
+            "SYSTEM".into()
+        );
+        assert_eq!(
+            *result.info_data.created_at.as_ref().unwrap(),
+            "2021-07-23T15:31:20.0Z".into()
+        );
+        assert_eq!(
+            *result.info_data.updater_id.as_ref().unwrap(),
+            "SYSTEM".into()
+        );
+        assert_eq!(
+            *result.info_data.updated_at.as_ref().unwrap(),
+            "2021-07-23T15:31:21.0Z".into()
+        );
+        assert_eq!(
+            *result.info_data.expiring_at.as_ref().unwrap(),
             "2023-07-23T15:31:20.0Z".into()
         );
         assert_eq!((*auth_info).password, "epP4uthd#v".into());
         assert_eq!(object.tr_ids.client_tr_id.unwrap(), CLTRID.into());
         assert_eq!(object.tr_ids.server_tr_id, SVTRID.into());
+    }
+
+    #[test]
+    fn domain_info_alt() {
+        let xml = get_xml("response/domain/info_alt.xml").unwrap();
+        DomainInfo::<NoExtension>::deserialize_response(xml.as_str()).unwrap();
     }
 
     #[test]

--- a/epp-client/src/tests/se.rs
+++ b/epp-client/src/tests/se.rs
@@ -298,7 +298,7 @@ mod request {
     fn domain_info() {
         let xml = get_xml("request/domain/info.xml").unwrap();
 
-        let object = DomainInfo::<NoExtension>::new("eppdev.com");
+        let object = DomainInfo::<NoExtension>::new("eppdev.com", Some("2fooBAR"));
 
         let serialized = object.serialize_request(CLTRID).unwrap();
 

--- a/epp-client/test/resources/request/domain/info.xml
+++ b/epp-client/test/resources/request/domain/info.xml
@@ -4,6 +4,9 @@
         <info>
             <domain:info xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
                 <domain:name hosts="all">eppdev.com</domain:name>
+                <domain:authInfo>
+                    <domain:pw>2fooBAR</domain:pw>
+                </domain:authInfo>
             </domain:info>
         </info>
         <clTRID>cltrid:1626454866</clTRID>

--- a/epp-client/test/resources/response/domain/info_alt.xml
+++ b/epp-client/test/resources/response/domain/info_alt.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+    <response>
+        <result code="1000">
+            <msg>Command completed successfully</msg>
+        </result>
+        <resData>
+            <domain:infData xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+                <domain:name>eppdev-1.com</domain:name>
+                <domain:roid>128410211_DOMAIN_COM-VRSN</domain:roid>
+                <domain:status s="clientDeleteProhibited"/>
+                <domain:status s="clientTransferProhibited"/>
+                <domain:status s="clientHold"/>
+                <domain:status s="clientUpdateProhibited"/>
+                <domain:ns>
+                    <domain:hostObj>ONE.NS.IDSTEST111.COM</domain:hostObj>
+                    <domain:hostObj>TWO.NS.IDSTEST111.COM</domain:hostObj>
+                </domain:ns>
+                <domain:host>TWO.NS.IDSTEST111.COM</domain:host>
+                <domain:host>ONE.NS.IDSTEST111.COM</domain:host>
+                <domain:clID>29000333</domain:clID>
+                <domain:crID>insdom1</domain:crID>
+                <domain:crDate>2021-12-01T23:41:40Z</domain:crDate>
+                <domain:upID>insdom1</domain:upID>
+                <domain:upDate>2021-12-01T23:41:40Z</domain:upDate>
+                <domain:exDate>2023-12-01T23:41:40Z</domain:exDate>
+                <domain:authInfo>
+                    <domain:pw>epP4uthd#v</domain:pw>
+                </domain:authInfo>
+            </domain:infData>
+        </resData>
+        <trID>
+            <clTRID>insdom1:1638402100</clTRID>
+            <svTRID>1123110370-1638402100935</svTRID>
+        </trID>
+    </response>
+</epp>


### PR DESCRIPTION
Closes #31

This pull request updates several of the fields in DomainInfo to be optional. It also updates DomainInfo to accept an optional auth_password parameter.

This pull request includes #30 and all of its children.