### PR TITLE
ser/de for contact status enum

### DIFF
--- a/epp-client/src/common.rs
+++ b/epp-client/src/common.rs
@@ -3,7 +3,9 @@
 use std::{fmt::Display, str::FromStr};
 
 use epp_client_macros::ElementName;
-use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
+use serde::{
+    de::Error as DeError, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer,
+};
 
 use crate::request::EppExtension;
 
@@ -265,6 +267,99 @@ impl Period {
     pub fn set_unit(&mut self, unit: &str) {
         self.unit = unit.to_string();
     }
+}
+
+#[derive(Deserialize, Debug, PartialEq)]
+#[serde(untagged)]
+pub enum Status {
+    OK,
+    ClientDeleteProhibited,
+    ClientHold,
+    ClientRenewProhibited,
+    ClientTransferProhibited,
+    ClientUpdateProhibited,
+    Inactive,
+    PendingCreate,
+    PendingDelete,
+    PendingRenew,
+    PendingTransfer,
+    PendingUpdate,
+    ServerDeleteProhibited,
+    ServerHold,
+    ServerRenewProhibited,
+    ServerTransferProhibited,
+    ServerUpdateProhibited,
+}
+
+impl Serialize for Status {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let enum_str = match self {
+            Status::OK => "ok",
+            Status::ClientDeleteProhibited => "clientDeleteProhibited",
+            Status::ClientHold => "clientHold",
+            Status::ClientRenewProhibited => "clientRenewProhibited",
+            Status::ClientTransferProhibited => "clientTransferProhibited",
+            Status::ClientUpdateProhibited => "clientUpdateProhibited",
+            Status::Inactive => "inactive",
+            Status::PendingCreate => "pendingCreate",
+            Status::PendingDelete => "pendingDelete",
+            Status::PendingRenew => "pemdingRenew",
+            Status::PendingTransfer => "pendingTransfer",
+            Status::PendingUpdate => "pendingUpdate",
+            Status::ServerDeleteProhibited => "serverDeleteProhibited",
+            Status::ServerHold => "serverHold",
+            Status::ServerRenewProhibited => "serverRenewProhibited",
+            Status::ServerTransferProhibited => "serverTransferProhibited",
+            Status::ServerUpdateProhibited => "serverUpdateProhibited",
+        };
+
+        serializer.serialize_str(&enum_str)
+    }
+}
+
+impl<'de> Deserialize<'de> for ContactStatusWithEnum {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let contact_status = DeserializeStatus::deserialize(deserializer)?;
+
+        let status = match contact_status.status.as_str() {
+            "ok" => Status::OK,
+            "clientDeleteProhibited" => Status::ClientDeleteProhibited,
+            "clientHold" => Status::ClientHold,
+            "clientRenewProhibited" => Status::ClientRenewProhibited,
+            "clientTransferProhibited" => Status::ClientTransferProhibited,
+            "clientUpdateProhibited" => Status::ClientUpdateProhibited,
+            "inactive" => Status::Inactive,
+            "pendingCreate" => Status::PendingCreate,
+            "pendingDelete" => Status::PendingDelete,
+            "pemdingRenew" => Status::PendingRenew,
+            "pendingTransfer" => Status::PendingTransfer,
+            "pendingUpdate" => Status::PendingUpdate,
+            "serverDeleteProhibited" => Status::ServerDeleteProhibited,
+            "serverHold" => Status::ServerHold,
+            "serverRenewProhibited" => Status::ServerRenewProhibited,
+            "serverTransferProhibited" => Status::ServerTransferProhibited,
+            "serverUpdateProhibited" => Status::ServerUpdateProhibited,
+            _ => return Err("Status Deserialization Error").map_err(DeError::custom),
+        };
+
+        Ok(ContactStatusWithEnum { status: status })
+    }
+}
+
+type DeserializeStatus = ContactStatus;
+
+/// The &lt;status&gt; type on contact transactions
+#[derive(Serialize, Debug)]
+pub struct ContactStatusWithEnum {
+    /// The status name, represented by the 's' attr on &lt;status&gt; tags
+    #[serde(rename = "s")]
+    pub status: Status,
 }
 
 /// The &lt;status&gt; type on contact transactions

--- a/epp-client/src/common.rs
+++ b/epp-client/src/common.rs
@@ -316,7 +316,7 @@ impl Serialize for Status {
             Status::ServerUpdateProhibited => "serverUpdateProhibited",
         };
 
-        serializer.serialize_str(&enum_str)
+        serializer.serialize_str(enum_str)
     }
 }
 
@@ -348,7 +348,7 @@ impl<'de> Deserialize<'de> for ContactStatusWithEnum {
             _ => return Err("Status Deserialization Error").map_err(DeError::custom),
         };
 
-        Ok(ContactStatusWithEnum { status: status })
+        Ok(ContactStatusWithEnum { status })
     }
 }
 

--- a/epp-client/src/contact/info.rs
+++ b/epp-client/src/contact/info.rs
@@ -4,7 +4,8 @@ use epp_client_macros::*;
 
 use super::XMLNS;
 use crate::common::{
-    ContactAuthInfo, ContactStatus, ElementName, NoExtension, Phone, PostalInfo, StringValue,
+    ContactAuthInfo, ContactStatusWithEnum, ElementName, NoExtension, Phone, PostalInfo,
+    StringValue,
 };
 use crate::request::{EppExtension, EppRequest};
 use serde::{Deserialize, Serialize};
@@ -135,7 +136,7 @@ pub struct ContactInfoData {
     pub roid: StringValue,
     /// The list of contact statuses
     #[serde(rename = "status")]
-    pub statuses: Vec<ContactStatus>,
+    pub statuses: Vec<ContactStatusWithEnum>,
     /// The postal info for the contact
     #[serde(rename = "postalInfo")]
     pub postal_info: PostalInfo,

--- a/epp-client/src/contact/update.rs
+++ b/epp-client/src/contact/update.rs
@@ -4,7 +4,8 @@ use epp_client_macros::*;
 
 use super::XMLNS;
 use crate::common::{
-    ContactAuthInfo, ContactStatusWithEnum, ElementName, NoExtension, Phone, PostalInfo, StringValue,
+    ContactAuthInfo, ContactStatusWithEnum, ElementName, NoExtension, Phone, PostalInfo,
+    StringValue,
 };
 use crate::request::{EppExtension, EppRequest};
 use crate::response::EppCommandResponse;
@@ -36,7 +37,7 @@ impl<E: EppExtension> EppRequest<E> for ContactUpdate<E> {
 /// use epp_client::EppClient;
 /// use epp_client::contact::update::ContactUpdate;
 /// use epp_client::generate_client_tr_id;
-/// use epp_client::common::ContactStatus;
+/// use epp_client::common::ContactStatusWithExtension;
 /// use epp_client::common::NoExtension;
 ///
 /// #[tokio::main]
@@ -68,8 +69,8 @@ impl<E: EppExtension> EppRequest<E> for ContactUpdate<E> {
 ///     );
 ///
 ///     let add_statuses = vec![
-///         ContactStatus {
-///             status: "clientTransferProhibited".to_string()
+///         ContactStatusWithExtension {
+///             status: Status::ClientTransferProhibited,
 ///         }
 ///     ];
 ///

--- a/epp-client/src/contact/update.rs
+++ b/epp-client/src/contact/update.rs
@@ -37,7 +37,7 @@ impl<E: EppExtension> EppRequest<E> for ContactUpdate<E> {
 /// use epp_client::EppClient;
 /// use epp_client::contact::update::ContactUpdate;
 /// use epp_client::generate_client_tr_id;
-/// use epp_client::common::ContactStatusWithExtension;
+/// use epp_client::common::{ContactStatusWithEnum, Status};
 /// use epp_client::common::NoExtension;
 ///
 /// #[tokio::main]
@@ -69,7 +69,7 @@ impl<E: EppExtension> EppRequest<E> for ContactUpdate<E> {
 ///     );
 ///
 ///     let add_statuses = vec![
-///         ContactStatusWithExtension {
+///         ContactStatusWithEnum {
 ///             status: Status::ClientTransferProhibited,
 ///         }
 ///     ];

--- a/epp-client/src/contact/update.rs
+++ b/epp-client/src/contact/update.rs
@@ -4,7 +4,7 @@ use epp_client_macros::*;
 
 use super::XMLNS;
 use crate::common::{
-    ContactAuthInfo, ContactStatus, ElementName, NoExtension, Phone, PostalInfo, StringValue,
+    ContactAuthInfo, ContactStatusWithEnum, ElementName, NoExtension, Phone, PostalInfo, StringValue,
 };
 use crate::request::{EppExtension, EppRequest};
 use crate::response::EppCommandResponse;
@@ -131,12 +131,12 @@ impl<E: EppExtension> ContactUpdate<E> {
     }
 
     /// Sets the data for the &lt;add&gt; tag for the contact update request
-    pub fn add(&mut self, statuses: Vec<ContactStatus>) {
+    pub fn add(&mut self, statuses: Vec<ContactStatusWithEnum>) {
         self.request.contact.add_statuses = Some(StatusList { status: statuses });
     }
 
     /// Sets the data for the &lt;rem&gt; tag for the contact update request
-    pub fn remove(&mut self, statuses: Vec<ContactStatus>) {
+    pub fn remove(&mut self, statuses: Vec<ContactStatusWithEnum>) {
         self.request.contact.remove_statuses = Some(StatusList { status: statuses });
     }
 }
@@ -160,7 +160,7 @@ pub struct ContactChangeInfo {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct StatusList {
     #[serde(rename = "contact:status", alias = "status")]
-    status: Vec<ContactStatus>,
+    status: Vec<ContactStatusWithEnum>,
 }
 
 /// Type for elements under the contact &lt;update&gt; tag

--- a/epp-client/src/tests/de.rs
+++ b/epp-client/src/tests/de.rs
@@ -3,7 +3,7 @@
 mod response {
     use super::super::get_xml;
     use super::super::CLTRID;
-    use crate::common::NoExtension;
+    use crate::common::{NoExtension, Status};
     use crate::contact::check::ContactCheck;
     use crate::contact::create::ContactCreate;
     use crate::contact::delete::ContactDelete;
@@ -168,6 +168,8 @@ mod response {
         let xml = get_xml("response/contact/info.xml").unwrap();
         let object = ContactInfo::<NoExtension>::deserialize_response(xml.as_str()).unwrap();
 
+        println!("{:?}", object);
+
         let result = object.res_data().unwrap();
         let fax = result.info_data.fax.as_ref().unwrap();
         let voice_ext = result.info_data.voice.extension.as_ref().unwrap();
@@ -178,7 +180,7 @@ mod response {
         assert_eq!(object.result.message, SUCCESS_MSG.into());
         assert_eq!(result.info_data.id, "eppdev-contact-3".into());
         assert_eq!(result.info_data.roid, "UNDEF-ROID".into());
-        assert_eq!(result.info_data.statuses[0].status, "ok".to_string());
+        assert_eq!(result.info_data.statuses[0].status, Status::OK);
         assert_eq!(result.info_data.postal_info.info_type, "loc".to_string());
         assert_eq!(result.info_data.postal_info.name, "John Doe".into());
         assert_eq!(

--- a/epp-client/src/tests/se.rs
+++ b/epp-client/src/tests/se.rs
@@ -8,7 +8,7 @@ mod request {
     use crate::common::HostObjList;
     use crate::common::NoExtension;
     use crate::common::{
-        Address, ContactStatus, DomainAuthInfo, DomainContact, DomainStatus, HostAddr, HostAttr,
+        Address, ContactStatusWithEnum, Status, DomainAuthInfo, DomainContact, DomainStatus, HostAddr, HostAttr,
         HostStatus, Phone, PostalInfo,
     };
     use crate::contact::check::ContactCheck;
@@ -137,12 +137,12 @@ mod request {
         let voice = Phone::new("+33.47237942");
 
         object.set_info("newemail@eppdev.net", postal_info, voice, "eppdev-387323");
-        let add_statuses = vec![ContactStatus {
-            status: "clientTransferProhibited".to_string(),
+        let add_statuses = vec![ContactStatusWithEnum {
+            status: Status::ClientTransferProhibited,
         }];
         object.add(add_statuses);
-        let remove_statuses = vec![ContactStatus {
-            status: "clientDeleteProhibited".to_string(),
+        let remove_statuses = vec![ContactStatusWithEnum {
+            status: Status::ClientDeleteProhibited,
         }];
         object.remove(remove_statuses);
 

--- a/epp-client/src/tests/se.rs
+++ b/epp-client/src/tests/se.rs
@@ -8,8 +8,8 @@ mod request {
     use crate::common::HostObjList;
     use crate::common::NoExtension;
     use crate::common::{
-        Address, ContactStatusWithEnum, Status, DomainAuthInfo, DomainContact, DomainStatus, HostAddr, HostAttr,
-        HostStatus, Phone, PostalInfo,
+        Address, ContactStatusWithEnum, DomainAuthInfo, DomainContact, DomainStatus, HostAddr,
+        HostAttr, HostStatus, Phone, PostalInfo, Status,
     };
     use crate::contact::check::ContactCheck;
     use crate::contact::create::ContactCreate;


### PR DESCRIPTION
Sample ser/de for a `ContactStatus` enum. Should be usable for `DomainStatus` as well with some edits.