### PR TITLE
rgp:infData should allow multiple rgp:rgpStatus

### DIFF
--- a/epp-client/src/common.rs
+++ b/epp-client/src/common.rs
@@ -98,7 +98,7 @@ impl Options {
 #[serde(rename = "extension")]
 pub struct Extension<E: ElementName> {
     /// Data under the &lt;extension&gt; tag
-    #[serde(alias = "upData", alias = "namestoreExt")]
+    #[serde(alias = "upData", alias = "namestoreExt", alias = "infData")]
     pub data: E,
 }
 

--- a/epp-client/src/extensions/rgp/request.rs
+++ b/epp-client/src/extensions/rgp/request.rs
@@ -125,5 +125,5 @@ pub struct RgpRequestResponse {
     xmlns: String,
     /// Data under the &lt;rgpStatus&gt; tag
     #[serde(rename = "rgpStatus")]
-    pub rgp_status: RgpStatus,
+    pub rgp_status: Vec<RgpStatus>,
 }

--- a/epp-client/src/tests/de.rs
+++ b/epp-client/src/tests/de.rs
@@ -643,8 +643,19 @@ mod response {
 
         assert_eq!(object.result.code, 1000);
         assert_eq!(object.result.message, SUCCESS_MSG.into());
-        assert_eq!(ext.data.rgp_status.status, "pendingRestore".to_string());
+        assert_eq!(ext.data.rgp_status[0].status, "pendingRestore".to_string());
         assert_eq!(object.tr_ids.server_tr_id, SVTRID.into());
+    }
+
+    #[test]
+    fn rgp_restore_domain_info_response() {
+        let xml = get_xml("response/extensions/domain_info_rgp.xml").unwrap();
+        let object = DomainInfo::<RgpRestoreRequest>::deserialize_response(xml.as_str()).unwrap();
+
+        let ext = object.extension.unwrap();
+
+        assert_eq!(ext.data.rgp_status[0].status, "addPeriod");
+        assert_eq!(ext.data.rgp_status[1].status, "renewPeriod");
     }
 
     #[test]

--- a/epp-client/test/resources/response/extensions/domain_info_rgp.xml
+++ b/epp-client/test/resources/response/extensions/domain_info_rgp.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+    <response>
+        <result code="1000">
+            <msg>Command completed successfully</msg>
+        </result>
+        <resData>
+            <domain:infData xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+                <domain:name>eppdev-1.com</domain:name>
+                <domain:roid>125899511_DOMAIN_COM-VRSN</domain:roid>
+                <domain:status s="ok"/>
+                <domain:status s="clientTransferProhibited"/>
+                <domain:registrant>eppdev-contact-2</domain:registrant>
+                <domain:contact type="admin">eppdev-contact-2</domain:contact>
+                <domain:contact type="tech">eppdev-contact-2</domain:contact>
+                <domain:contact type="billing">eppdev-contact-2</domain:contact>
+                <domain:ns>
+                    <domain:hostObj>ns1.eppdev-1.com</domain:hostObj>
+                    <domain:hostObj>ns2.eppdev-1.com</domain:hostObj>
+                </domain:ns>
+                <domain:host>ns1.eppdev-1.com</domain:host>
+                <domain:host>ns2.eppdev-1.com</domain:host>
+                <domain:clID>eppdev</domain:clID>
+                <domain:crID>SYSTEM</domain:crID>
+                <domain:crDate>2021-07-23T15:31:20.0Z</domain:crDate>
+                <domain:upID>SYSTEM</domain:upID>
+                <domain:upDate>2021-07-23T15:31:21.0Z</domain:upDate>
+                <domain:exDate>2023-07-23T15:31:20.0Z</domain:exDate>
+                <domain:authInfo>
+                    <domain:pw>epP4uthd#v</domain:pw>
+                </domain:authInfo>
+            </domain:infData>
+        </resData>
+        <extension>
+            <rgp:infData xmlns:rgp="urn:ietf:params:xml:ns:rgp-1.0">
+                <rgp:rgpStatus s="addPeriod">endDate=2021-12-07T19:08:08Z</rgp:rgpStatus>
+                <rgp:rgpStatus s="renewPeriod">endDate=2021-12-07T23:07:49Z</rgp:rgpStatus>
+            </rgp:infData>
+        </extension>
+        <trID>
+            <clTRID>cltrid:1626454866</clTRID>
+            <svTRID>RO-6879-1627224678242975</svTRID>
+        </trID>
+    </response>
+</epp>


### PR DESCRIPTION
This actually goes against what defined in the spec: https://datatracker.ietf.org/doc/html/rfc3915#section-4.1.2

```
   The <rgp:infData> element contains a single <rgp:rgpStatus> element that
   contains a single attribute "s" whose value describes the current
   grace period status of the domain.
```

However, the response I'm seeing from VeriSign contains multiple children. So I'm guessing the spec is slightly out of date.