### PR TITLE
Make exDate always optional

### DIFF
--- a/src/domain/create.rs
+++ b/src/domain/create.rs
@@ -89,7 +89,7 @@ pub struct DomainCreateResponseData {
     pub created_at: StringValue,
     /// The expiry date
     #[serde(rename = "exDate")]
-    pub expiring_at: StringValue,
+    pub expiring_at: Option<StringValue>,
 }
 
 /// Type that represents the &lt;resData&gt; tag for domain create response
@@ -250,7 +250,7 @@ mod tests {
             "2021-07-25T18:11:35.0Z".into()
         );
         assert_eq!(
-            result.create_data.expiring_at,
+            *result.create_data.expiring_at.as_ref().unwrap(),
             "2022-07-25T18:11:34.0Z".into()
         );
         assert_eq!(object.tr_ids.client_tr_id.unwrap(), CLTRID.into());

--- a/src/domain/renew.rs
+++ b/src/domain/renew.rs
@@ -63,7 +63,7 @@ pub struct DomainRenewResponseData {
     pub name: StringValue,
     /// The new expiry date after renewal
     #[serde(rename = "exDate")]
-    pub expiring_at: StringValue,
+    pub expiring_at: Option<StringValue>,
 }
 
 /// Type that represents the &lt;resData&gt; tag for domain renew response
@@ -108,7 +108,7 @@ mod tests {
         assert_eq!(object.result.message, SUCCESS_MSG.into());
         assert_eq!(result.renew_data.name, "eppdev-1.com".into());
         assert_eq!(
-            result.renew_data.expiring_at,
+            *result.renew_data.expiring_at.as_ref().unwrap(),
             "2024-07-23T15:31:20.0Z".into()
         );
         assert_eq!(object.tr_ids.client_tr_id.unwrap(), CLTRID.into());

--- a/src/message/poll.rs
+++ b/src/message/poll.rs
@@ -52,7 +52,7 @@ pub struct MessageDomainTransferData {
     pub ack_by: StringValue,
     /// The domain expiry date
     #[serde(rename = "domain:exDate", alias = "exDate")]
-    pub expiring_at: StringValue,
+    pub expiring_at: Option<StringValue>,
 }
 
 /// Type that represents the &lt;resData&gt; tag for message poll response
@@ -113,7 +113,7 @@ mod tests {
         assert_eq!(result.message_data.ack_id, "ClientY".into());
         assert_eq!(result.message_data.ack_by, "2021-07-28T15:31:21.0Z".into());
         assert_eq!(
-            result.message_data.expiring_at,
+            *result.message_data.expiring_at.as_ref().unwrap(),
             "2022-07-02T14:53:19.0Z".into()
         );
         assert_eq!(object.tr_ids.client_tr_id.unwrap(), CLTRID.into());


### PR DESCRIPTION
This is an extension of #44. I missed other occurrences of this.