### PR TITLE
Add sync namestore composite extension

### DIFF
--- a/src/extensions/consolidate.rs
+++ b/src/extensions/consolidate.rs
@@ -9,12 +9,20 @@ use crate::common::{NoExtension, StringValue};
 use crate::domain::update::DomainUpdate;
 use crate::request::{Extension, Transaction};
 
+use super::namestore::{NameStore, NameStoreData};
+
 pub const XMLNS: &str = "http://www.verisign.com/epp/sync-1.0";
 
 impl Transaction<Update> for DomainUpdate {}
 
 impl Extension for Update {
     type Response = NoExtension;
+}
+
+impl Transaction<UpdateWithNameStore> for DomainUpdate {}
+
+impl Extension for UpdateWithNameStore {
+    type Response = NameStore;
 }
 
 #[derive(PartialEq, Debug)]
@@ -59,7 +67,7 @@ impl fmt::Display for GMonthDay {
 }
 
 impl Update {
-    /// Create a new RGP restore report request
+    /// Create a new sync update request
     pub fn new(expiration: GMonthDay) -> Self {
         Self {
             data: UpdateData {
@@ -70,10 +78,28 @@ impl Update {
     }
 }
 
+impl UpdateWithNameStore {
+    /// Create a new sync update with namestore request
+    pub fn new(expiration: GMonthDay, subproduct: &str) -> Self {
+        Self {
+            sync: Update::new(expiration).data,
+            namestore: NameStore::new(subproduct).data,
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct Update {
     #[serde(rename = "sync:update")]
     pub data: UpdateData,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UpdateWithNameStore {
+    #[serde(rename = "sync:update")]
+    pub sync: UpdateData,
+    #[serde(rename = "namestoreExt:namestoreExt")]
+    pub namestore: NameStoreData,
 }
 
 #[derive(Serialize, Debug)]
@@ -91,6 +117,7 @@ pub struct UpdateData {
 mod tests {
     use super::{GMonthDay, Update};
     use crate::domain::update::{DomainChangeInfo, DomainUpdate};
+    use crate::extensions::consolidate::UpdateWithNameStore;
     use crate::request::Transaction;
     use crate::tests::{get_xml, CLTRID};
 
@@ -110,6 +137,31 @@ mod tests {
         });
 
         let serialized = <DomainUpdate as Transaction<Update>>::serialize_request(
+            &object,
+            Some(&consolidate_ext),
+            CLTRID,
+        )
+        .unwrap();
+
+        assert_eq!(xml, serialized);
+    }
+
+    #[test]
+    fn command_with_namestore() {
+        let xml = get_xml("request/extensions/consolidate_namestore.xml").unwrap();
+
+        let exp = GMonthDay::new(5, 31, None).unwrap();
+
+        let consolidate_ext = UpdateWithNameStore::new(exp, "com");
+
+        let mut object = DomainUpdate::new("eppdev.com");
+
+        object.info(DomainChangeInfo {
+            registrant: None,
+            auth_info: None,
+        });
+
+        let serialized = <DomainUpdate as Transaction<UpdateWithNameStore>>::serialize_request(
             &object,
             Some(&consolidate_ext),
             CLTRID,

--- a/test/resources/request/extensions/consolidate_namestore.xml
+++ b/test/resources/request/extensions/consolidate_namestore.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+    <command>
+        <update>
+            <domain:update xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+                <domain:name>eppdev.com</domain:name>
+                <domain:chg/>
+            </domain:update>
+        </update>
+        <extension>
+            <sync:update xmlns:sync="http://www.verisign.com/epp/sync-1.0">
+                <sync:expMonthDay>--05-31</sync:expMonthDay>
+            </sync:update>
+            <namestoreExt:namestoreExt xmlns:namestoreExt="http://www.verisign-grs.com/epp/namestoreExt-1.1">
+                <namestoreExt:subProduct>com</namestoreExt:subProduct>
+            </namestoreExt:namestoreExt>
+        </extension>
+        <clTRID>cltrid:1626454866</clTRID>
+    </command>
+</epp>


### PR DESCRIPTION
Closes #45 

This pull request introduces an extension that combines namestore and sync. It's also possible to create a custom extension combination external to this crate but I think it makes sense to offer this combination because it offers both namestore and sync already.

Example of custom extension combination from calling context:

```rust

#[derive(Deserialize, Serialize, Debug)]
#[serde(transparent)]
pub struct NameStoreWithRgpResponse(pub NameStore);

impl Transaction<NameStoreWithRgpResponse> for DomainInfo {}

impl Extension for NameStoreWithRgpResponse {
    type Response = Update<RgpRequestResponse>;
}

let namestore_com_rpg_ext = NameStoreWithRgpResponse {
    0: NameStore::new("com"),
};
```