### PR TITLE
Make error handling more consistent/standard

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -33,7 +33,6 @@
 //! }
 //! ```
 
-use std::error::Error as StdError;
 use std::net::SocketAddr;
 
 use crate::common::{Certificate, NoExtension, PrivateKey};
@@ -59,14 +58,14 @@ impl EppClient {
         addr: SocketAddr,
         hostname: &str,
         identity: Option<(Vec<Certificate>, PrivateKey)>,
-    ) -> Result<Self, Box<dyn StdError>> {
+    ) -> Result<Self, Error> {
         Ok(Self {
             connection: EppConnection::connect(registry, addr, hostname, identity).await?,
         })
     }
 
     /// Executes an EPP Hello call and returns the response as an `Greeting`
-    pub async fn hello(&mut self) -> Result<Greeting, Box<dyn StdError>> {
+    pub async fn hello(&mut self) -> Result<Greeting, Error> {
         let hello_xml = HelloDocument::default().serialize()?;
 
         let response = self.connection.transact(&hello_xml).await?;
@@ -93,7 +92,7 @@ impl EppClient {
 
     /// Accepts raw EPP XML and returns the raw EPP XML response to it.
     /// Not recommended for direct use but sometimes can be useful for debugging
-    pub async fn transact_xml(&mut self, xml: &str) -> Result<String, Box<dyn StdError>> {
+    pub async fn transact_xml(&mut self, xml: &str) -> Result<String, Error> {
         self.connection.transact(xml).await
     }
 
@@ -107,7 +106,7 @@ impl EppClient {
         GreetingDocument::deserialize(&self.connection.greeting).map(|obj| obj.data)
     }
 
-    pub async fn shutdown(mut self) -> Result<(), Box<dyn StdError>> {
+    pub async fn shutdown(mut self) -> Result<(), Error> {
         self.connection.shutdown().await
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -147,7 +147,7 @@ async fn epp_connect(
                 .collect();
             builder
                 .with_single_cert(certs, rustls::PrivateKey(key.0))
-                .map_err(|e| Error::Other(e.to_string()))?
+                .map_err(|e| Error::Other(e.into()))?
         }
         None => builder.with_no_client_auth(),
     };

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,9 +43,3 @@ impl From<std::io::ErrorKind> for Error {
         Self::EppConnectionError(std::io::Error::from(e))
     }
 }
-
-impl From<String> for Error {
-    fn from(e: String) -> Self {
-        Self::Other(e)
-    }
-}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,16 @@
 //! Error types to wrap internal errors and make EPP errors easier to read
 
-use crate::response::ResponseStatus;
+use std::error::Error as StdError;
 use std::fmt::Display;
+
+use crate::response::ResponseStatus;
 
 /// Error enum holding the possible error types
 #[derive(Debug)]
 pub enum Error {
     Io(std::io::Error),
     Command(ResponseStatus),
-    Deserialize(String),
+    Xml(Box<dyn StdError>),
     Other(String),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,9 @@
 use std::error::Error as StdError;
 use std::fmt::{self, Display};
 use std::io;
+use std::num::TryFromIntError;
+use std::str::Utf8Error;
+use std::string::FromUtf8Error;
 
 use crate::response::ResponseStatus;
 
@@ -44,5 +47,23 @@ impl From<io::Error> for Error {
 impl From<io::ErrorKind> for Error {
     fn from(e: io::ErrorKind) -> Self {
         Self::Io(io::Error::from(e))
+    }
+}
+
+impl From<TryFromIntError> for Error {
+    fn from(e: TryFromIntError) -> Self {
+        Self::Other(e.into())
+    }
+}
+
+impl From<FromUtf8Error> for Error {
+    fn from(e: FromUtf8Error) -> Self {
+        Self::Other(e.into())
+    }
+}
+
+impl From<Utf8Error> for Error {
+    fn from(e: Utf8Error) -> Self {
+        Self::Other(e.into())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,7 @@ pub enum Error {
     Io(std::io::Error),
     Command(ResponseStatus),
     Xml(Box<dyn StdError>),
-    Other(String),
+    Other(Box<dyn StdError>),
 }
 
 impl StdError for Error {}
@@ -31,7 +31,7 @@ impl Display for Error {
 
 impl From<Box<dyn StdError>> for Error {
     fn from(e: Box<dyn StdError>) -> Self {
-        Self::Other(format!("{:?}", e))
+        Self::Other(e)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,9 +6,9 @@ use std::fmt::Display;
 /// Error enum holding the possible error types
 #[derive(Debug)]
 pub enum Error {
-    EppConnectionError(std::io::Error),
-    EppCommandError(ResponseStatus),
-    EppDeserializationError(String),
+    Io(std::io::Error),
+    Command(ResponseStatus),
+    Deserialize(String),
     Other(String),
 }
 
@@ -17,7 +17,7 @@ impl std::error::Error for Error {}
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::EppCommandError(e) => {
+            Error::Command(e) => {
                 write!(f, "epp-client EppCommandError: {}", e.result.message)
             }
             Error::Other(e) => write!(f, "epp-client Exception: {}", e),
@@ -34,12 +34,12 @@ impl From<std::boxed::Box<dyn std::error::Error>> for Error {
 
 impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Self {
-        Self::EppConnectionError(e)
+        Self::Io(e)
     }
 }
 
 impl From<std::io::ErrorKind> for Error {
     fn from(e: std::io::ErrorKind) -> Self {
-        Self::EppConnectionError(std::io::Error::from(e))
+        Self::Io(std::io::Error::from(e))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,8 @@
 //! Error types to wrap internal errors and make EPP errors easier to read
 
 use std::error::Error as StdError;
-use std::fmt::Display;
+use std::fmt::{self, Display};
+use std::io;
 
 use crate::response::ResponseStatus;
 
@@ -14,10 +15,10 @@ pub enum Error {
     Other(String),
 }
 
-impl std::error::Error for Error {}
+impl StdError for Error {}
 
 impl Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::Command(e) => {
                 write!(f, "epp-client EppCommandError: {}", e.result.message)
@@ -28,20 +29,20 @@ impl Display for Error {
     }
 }
 
-impl From<std::boxed::Box<dyn std::error::Error>> for Error {
-    fn from(e: std::boxed::Box<dyn std::error::Error>) -> Self {
+impl From<Box<dyn StdError>> for Error {
+    fn from(e: Box<dyn StdError>) -> Self {
         Self::Other(format!("{:?}", e))
     }
 }
 
-impl From<std::io::Error> for Error {
-    fn from(e: std::io::Error) -> Self {
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
         Self::Io(e)
     }
 }
 
-impl From<std::io::ErrorKind> for Error {
-    fn from(e: std::io::ErrorKind) -> Self {
-        Self::Io(std::io::Error::from(e))
+impl From<io::ErrorKind> for Error {
+    fn from(e: io::ErrorKind) -> Self {
+        Self::Io(io::Error::from(e))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,12 +12,6 @@ pub enum Error {
     Other(String),
 }
 
-/// An EPP XML error
-#[derive(Debug)]
-pub struct EppCommandError {
-    pub epp_error: ResponseStatus,
-}
-
 impl std::error::Error for Error {}
 
 impl Display for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,11 +23,12 @@ impl StdError for Error {}
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Error::Io(e) => write!(f, "I/O error: {}", e),
             Error::Command(e) => {
-                write!(f, "epp-client EppCommandError: {}", e.result.message)
+                write!(f, "command error: {}", e.result.message)
             }
-            Error::Other(e) => write!(f, "epp-client Exception: {}", e),
-            _ => write!(f, "epp-client Exception: {:?}", self),
+            Error::Xml(e) => write!(f, "(de)serialization error: {}", e),
+            Error::Other(e) => write!(f, "error: {}", e),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,16 +90,15 @@
 pub mod client;
 pub mod common;
 pub mod connection;
+pub mod contact;
 pub mod domain;
-pub mod error;
+mod error;
 pub mod hello;
 pub mod login;
 pub mod logout;
 pub mod request;
 pub mod response;
 pub mod xml;
-
-pub mod contact;
 
 pub mod extensions {
     pub mod consolidate;
@@ -123,6 +122,7 @@ pub mod message {
 }
 
 pub use client::EppClient;
+pub use error::Error;
 
 #[cfg(test)]
 pub mod tests;

--- a/src/request.rs
+++ b/src/request.rs
@@ -34,7 +34,7 @@ pub trait Transaction<Ext: Extension>: Command + Sized {
             <ResponseDocument<Self::Response, Ext::Response> as EppXml>::deserialize(epp_xml)?;
         match rsp.data.result.code {
             0..=2000 => Ok(rsp.data),
-            _ => Err(crate::error::Error::EppCommandError(ResponseStatus {
+            _ => Err(crate::error::Error::Command(ResponseStatus {
                 result: rsp.data.result,
                 tr_ids: rsp.data.tr_ids,
             })),

--- a/src/request.rs
+++ b/src/request.rs
@@ -18,7 +18,7 @@ pub trait Transaction<Ext: Extension>: Command + Sized {
         &self,
         extension: Option<&Ext>,
         client_tr_id: &str,
-    ) -> Result<String, Box<dyn std::error::Error>> {
+    ) -> Result<String, crate::error::Error> {
         <CommandDocument<Self, Ext> as EppXml>::serialize(&CommandDocument::new(CommandWrapper {
             command: Self::COMMAND,
             data: self,

--- a/src/request.rs
+++ b/src/request.rs
@@ -7,6 +7,7 @@ use crate::{
     common::{StringValue, EPP_XMLNS},
     response::{Response, ResponseDocument, ResponseStatus},
     xml::EppXml,
+    Error,
 };
 
 pub const EPP_VERSION: &str = "1.0";
@@ -18,7 +19,7 @@ pub trait Transaction<Ext: Extension>: Command + Sized {
         &self,
         extension: Option<&Ext>,
         client_tr_id: &str,
-    ) -> Result<String, crate::error::Error> {
+    ) -> Result<String, Error> {
         <CommandDocument<Self, Ext> as EppXml>::serialize(&CommandDocument::new(CommandWrapper {
             command: Self::COMMAND,
             data: self,
@@ -29,7 +30,7 @@ pub trait Transaction<Ext: Extension>: Command + Sized {
 
     fn deserialize_response(
         epp_xml: &str,
-    ) -> Result<Response<Self::Response, Ext::Response>, crate::error::Error> {
+    ) -> Result<Response<Self::Response, Ext::Response>, Error> {
         let rsp =
             <ResponseDocument<Self::Response, Ext::Response> as EppXml>::deserialize(epp_xml)?;
         match rsp.data.result.code {

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -1,41 +1,30 @@
 //! Types to use in serialization to and deserialization from EPP XML
 
-use quick_xml::de::from_str;
-use quick_xml::se;
 use serde::{de::DeserializeOwned, Serialize};
-use std::error::Error;
 
-use crate::error;
+use crate::error::Error;
 
 pub const EPP_XML_HEADER: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="no"?>"#;
 
 /// Trait to be implemented by serializers. Currently the only included serializer is `quick-xml`
 pub trait EppXml: Sized {
     /// Serializes the EppObject instance to an EPP XML document
-    fn serialize(&self) -> Result<String, Box<dyn Error>>
+    fn serialize(&self) -> Result<String, Error>
     where
         Self: Serialize,
     {
-        let epp_xml = format!("{}\r\n{}", EPP_XML_HEADER, se::to_string(self)?);
-
-        Ok(epp_xml)
+        Ok(format!(
+            "{}\r\n{}",
+            EPP_XML_HEADER,
+            quick_xml::se::to_string(self).map_err(|e| Error::Xml(e.into()))?
+        ))
     }
 
     /// Deserializes an EPP XML document to an EppObject instance
-    fn deserialize(epp_xml: &str) -> Result<Self, error::Error>
+    fn deserialize(epp_xml: &str) -> Result<Self, Error>
     where
         Self: DeserializeOwned + Sized,
     {
-        let object: Self = match from_str(epp_xml) {
-            Ok(v) => v,
-            Err(e) => {
-                return Err(error::Error::Deserialize(format!(
-                    "epp-client Deserialization Error: {}",
-                    e
-                )))
-            }
-        };
-        // object.xml = Some(epp_xml.to_string());
-        Ok(object)
+        quick_xml::de::from_str::<Self>(epp_xml).map_err(|e| Error::Xml(e.into()))
     }
 }

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -29,7 +29,7 @@ pub trait EppXml: Sized {
         let object: Self = match from_str(epp_xml) {
             Ok(v) => v,
             Err(e) => {
-                return Err(error::Error::EppDeserializationError(format!(
+                return Err(error::Error::Deserialize(format!(
                     "epp-client Deserialization Error: {}",
                     e
                 )))


### PR DESCRIPTION
The code is currently pretty inconsistent about using the local `Error` type vs a `Box<dyn std::error::Error>`. This PR moves the library to consistently returning `Error` to match common style in the library ecosystem.