### PR TITLE
Make sure Error implements Send and Sync

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -14,8 +14,8 @@ use crate::response::ResponseStatus;
 pub enum Error {
     Io(std::io::Error),
     Command(ResponseStatus),
-    Xml(Box<dyn StdError>),
-    Other(Box<dyn StdError>),
+    Xml(Box<dyn StdError + Send + Sync>),
+    Other(Box<dyn StdError + Send + Sync>),
 }
 
 impl StdError for Error {}
@@ -33,8 +33,8 @@ impl Display for Error {
     }
 }
 
-impl From<Box<dyn StdError>> for Error {
-    fn from(e: Box<dyn StdError>) -> Self {
+impl From<Box<dyn StdError + Send + Sync>> for Error {
+    fn from(e: Box<dyn StdError + Send + Sync>) -> Self {
         Self::Other(e)
     }
 }


### PR DESCRIPTION
This is useful to have for some downstream usage (for example, to convert `Error` into `anyhow::Error`).