### PR TITLE
Take Login ext_uris values as a slice to allow caller to avoid allocation

### DIFF
--- a/src/login.rs
+++ b/src/login.rs
@@ -27,8 +27,8 @@ pub struct Login<'a> {
 }
 
 impl<'a> Login<'a> {
-    pub fn new(username: &'a str, password: &'a str, ext_uris: Option<Vec<&'a str>>) -> Self {
-        let ext_uris = ext_uris.map(|uris| uris.into_iter().map(|u| u.into()).collect());
+    pub fn new(username: &'a str, password: &'a str, ext_uris: Option<&'_ [&'a str]>) -> Self {
+        let ext_uris = ext_uris.map(|uris| uris.iter().map(|&u| u.into()).collect());
 
         Self {
             username: username.into(),
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     fn command() {
-        let ext_uris = Some(vec!["http://schema.ispapi.net/epp/xml/keyvalue-1.0"]);
+        let ext_uris = Some(&["http://schema.ispapi.net/epp/xml/keyvalue-1.0"][..]);
 
         let xml = get_xml("request/login.xml").unwrap();
         let object = Login::new("username", "password", ext_uris);

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -92,7 +92,7 @@ async fn client() {
             &Login::new(
                 "username",
                 "password",
-                Some(vec!["http://schema.ispapi.net/epp/xml/keyvalue-1.0"]),
+                Some(&["http://schema.ispapi.net/epp/xml/keyvalue-1.0"]),
             ),
             CLTRID,
         )


### PR DESCRIPTION
In some cases the caller might be able to use a const slice for this.