### PR TITLE
Change DomainAvailable::available to be a bool

### DIFF
--- a/src/domain/check.rs
+++ b/src/domain/check.rs
@@ -54,7 +54,7 @@ pub struct DomainAvailable {
     pub name: StringValue<'static>,
     /// The domain (un)availability
     #[serde(rename = "avail")]
-    pub available: u16,
+    pub available: bool,
 }
 
 /// Type that represents the &lt;cd&gt; tag for domain check response
@@ -117,12 +117,12 @@ mod tests {
             result.check_data.domain_list[0].domain.name,
             "eppdev.com".into()
         );
-        assert_eq!(result.check_data.domain_list[0].domain.available, 1);
+        assert!(result.check_data.domain_list[0].domain.available);
         assert_eq!(
             result.check_data.domain_list[1].domain.name,
             "eppdev.net".into()
         );
-        assert_eq!(result.check_data.domain_list[1].domain.available, 0);
+        assert!(!result.check_data.domain_list[1].domain.available);
         assert_eq!(object.tr_ids.client_tr_id.unwrap(), CLTRID.into());
         assert_eq!(object.tr_ids.server_tr_id, SVTRID.into());
     }

--- a/tests/resources/response/domain/check.xml
+++ b/tests/resources/response/domain/check.xml
@@ -10,7 +10,7 @@
                     <domain:name avail="1">eppdev.com</domain:name>
                 </domain:cd>
                 <domain:cd>
-                    <domain:name avail="0">eppdev.net</domain:name>
+                    <domain:name avail="false">eppdev.net</domain:name>
                 </domain:cd>
             </domain:chkData>
         </resData>


### PR DESCRIPTION
From RFC 5731:

    This element MUST contain an "avail" attribute whose value indicates
    object availability (can it be provisioned or not) at the moment the
    <check> command was completed.  A value of "1" or "true" means that
    the object can be provisioned.  A value of "0" or "false" means that
    the object can not be provisioned.