### PR TITLE
Share check response types and improve interface

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -26,7 +26,7 @@
 //! println!("{:?}", greeting);
 //!
 //! // Execute an EPP Command against the registry with distinct request and response objects
-//! let domain_check = DomainCheck::new(vec!["eppdev.com", "eppdev.net"]);
+//! let domain_check = DomainCheck { domains: &["eppdev.com", "eppdev.net"] };
 //! let response = client.transact(&domain_check, "transaction-id").await.unwrap();
 //! println!("{:?}", response);
 //!

--- a/src/common.rs
+++ b/src/common.rs
@@ -50,6 +50,32 @@ pub struct Available {
     pub available: bool,
 }
 
+/// Type that represents the &lt;cd&gt; tag for domain check response
+#[derive(Deserialize, Debug)]
+pub struct CheckResponseDataItem {
+    /// Data under the &lt;name&gt; tag
+    #[serde(rename = "name")]
+    pub resource: Available,
+    /// The reason for (un)availability
+    pub reason: Option<StringValue<'static>>,
+}
+
+/// Type that represents the &lt;chkData&gt; tag for host check response
+#[derive(Deserialize, Debug)]
+pub struct CheckData {
+    /// Data under the &lt;cd&gt; tag
+    #[serde(rename = "cd")]
+    pub list: Vec<CheckResponseDataItem>,
+}
+
+/// Type that represents the &lt;resData&gt; tag for host check response
+#[derive(Deserialize, Debug)]
+pub struct CheckResponse {
+    /// Data under the &lt;chkData&gt; tag
+    #[serde(rename = "chkData")]
+    pub check_data: CheckData,
+}
+
 /// The <option> type in EPP XML login requests
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename = "options")]

--- a/src/common.rs
+++ b/src/common.rs
@@ -39,6 +39,17 @@ impl Extension for NoExtension {
     type Response = NoExtension;
 }
 
+/// Type that represents the &lt;name&gt; tag for host check response
+#[derive(Deserialize, Debug)]
+pub struct Available {
+    /// The resource name
+    #[serde(rename = "$value")]
+    pub name: StringValue<'static>,
+    /// The resource (un)availability
+    #[serde(rename = "avail")]
+    pub available: bool,
+}
+
 /// The <option> type in EPP XML login requests
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename = "options")]

--- a/src/common.rs
+++ b/src/common.rs
@@ -44,7 +44,7 @@ impl Extension for NoExtension {
 pub struct Available {
     /// The resource name
     #[serde(rename = "$value")]
-    pub name: StringValue<'static>,
+    pub id: StringValue<'static>,
     /// The resource (un)availability
     #[serde(rename = "avail")]
     pub available: bool,
@@ -54,7 +54,7 @@ pub struct Available {
 #[derive(Deserialize, Debug)]
 pub struct CheckResponseDataItem {
     /// Data under the &lt;name&gt; tag
-    #[serde(rename = "name")]
+    #[serde(rename = "name", alias = "id")]
     pub resource: Available,
     /// The reason for (un)availability
     pub reason: Option<StringValue<'static>>,

--- a/src/contact/check.rs
+++ b/src/contact/check.rs
@@ -55,7 +55,7 @@ pub struct ContactAvailable {
     pub id: StringValue<'static>,
     /// The avail attr on the &lt;id&gt; tag
     #[serde(rename = "avail")]
-    pub available: u16,
+    pub available: bool,
 }
 
 /// Type that represents the &lt;cd&gt; tag for contact check response
@@ -117,12 +117,12 @@ mod tests {
             results.check_data.contact_list[0].contact.id,
             "eppdev-contact-1".into()
         );
-        assert_eq!(results.check_data.contact_list[0].contact.available, 0);
+        assert!(!results.check_data.contact_list[0].contact.available);
         assert_eq!(
             results.check_data.contact_list[1].contact.id,
             "eppdev-contact-2".into()
         );
-        assert_eq!(results.check_data.contact_list[1].contact.available, 1);
+        assert!(results.check_data.contact_list[1].contact.available);
         assert_eq!(object.tr_ids.client_tr_id.unwrap(), CLTRID.into());
         assert_eq!(object.tr_ids.server_tr_id, SVTRID.into());
     }

--- a/src/contact/check.rs
+++ b/src/contact/check.rs
@@ -74,16 +74,10 @@ mod tests {
 
         assert_eq!(object.result.code, ResultCode::CommandCompletedSuccessfully);
         assert_eq!(object.result.message, SUCCESS_MSG.into());
-        assert_eq!(
-            results.check_data.list[0].resource.id,
-            "eppdev-contact-1".into()
-        );
-        assert!(!results.check_data.list[0].resource.available);
-        assert_eq!(
-            results.check_data.list[1].resource.id,
-            "eppdev-contact-2".into()
-        );
-        assert!(results.check_data.list[1].resource.available);
+        assert_eq!(results.list[0].id, "eppdev-contact-1");
+        assert!(!results.list[0].available);
+        assert_eq!(results.list[1].id, "eppdev-contact-2");
+        assert!(results.list[1].available);
         assert_eq!(object.tr_ids.client_tr_id.unwrap(), CLTRID.into());
         assert_eq!(object.tr_ids.server_tr_id, SVTRID.into());
     }

--- a/src/domain/check.rs
+++ b/src/domain/check.rs
@@ -1,7 +1,7 @@
 //! Types for EPP domain check request
 
 use super::XMLNS;
-use crate::common::{NoExtension, StringValue};
+use crate::common::{NoExtension, StringValue, Available};
 use crate::request::{Command, Transaction};
 use serde::{Deserialize, Serialize};
 
@@ -46,23 +46,12 @@ pub struct DomainCheck<'a> {
 
 // Response
 
-/// Type that represents the &lt;name&gt; tag for domain check response
-#[derive(Deserialize, Debug)]
-pub struct DomainAvailable {
-    /// The domain name
-    #[serde(rename = "$value")]
-    pub name: StringValue<'static>,
-    /// The domain (un)availability
-    #[serde(rename = "avail")]
-    pub available: bool,
-}
-
 /// Type that represents the &lt;cd&gt; tag for domain check response
 #[derive(Deserialize, Debug)]
 pub struct DomainCheckResponseDataItem {
     /// Data under the &lt;name&gt; tag
     #[serde(rename = "name")]
-    pub domain: DomainAvailable,
+    pub domain: Available,
     /// The reason for (un)availability
     pub reason: Option<StringValue<'static>>,
 }

--- a/src/domain/check.rs
+++ b/src/domain/check.rs
@@ -75,9 +75,9 @@ mod tests {
 
         assert_eq!(object.result.code, ResultCode::CommandCompletedSuccessfully);
         assert_eq!(object.result.message, SUCCESS_MSG.into());
-        assert_eq!(result.check_data.list[0].resource.name, "eppdev.com".into());
+        assert_eq!(result.check_data.list[0].resource.id, "eppdev.com".into());
         assert!(result.check_data.list[0].resource.available);
-        assert_eq!(result.check_data.list[1].resource.name, "eppdev.net".into());
+        assert_eq!(result.check_data.list[1].resource.id, "eppdev.net".into());
         assert!(!result.check_data.list[1].resource.available);
         assert_eq!(object.tr_ids.client_tr_id.unwrap(), CLTRID.into());
         assert_eq!(object.tr_ids.server_tr_id, SVTRID.into());

--- a/src/domain/check.rs
+++ b/src/domain/check.rs
@@ -75,10 +75,10 @@ mod tests {
 
         assert_eq!(object.result.code, ResultCode::CommandCompletedSuccessfully);
         assert_eq!(object.result.message, SUCCESS_MSG.into());
-        assert_eq!(result.check_data.list[0].resource.id, "eppdev.com".into());
-        assert!(result.check_data.list[0].resource.available);
-        assert_eq!(result.check_data.list[1].resource.id, "eppdev.net".into());
-        assert!(!result.check_data.list[1].resource.available);
+        assert_eq!(result.list[0].id, "eppdev.com");
+        assert!(result.list[0].available);
+        assert_eq!(result.list[1].id, "eppdev.net");
+        assert!(!result.list[1].available);
         assert_eq!(object.tr_ids.client_tr_id.unwrap(), CLTRID.into());
         assert_eq!(object.tr_ids.server_tr_id, SVTRID.into());
     }

--- a/src/domain/check.rs
+++ b/src/domain/check.rs
@@ -1,14 +1,14 @@
 //! Types for EPP domain check request
 
 use super::XMLNS;
-use crate::common::{NoExtension, StringValue, Available};
+use crate::common::{CheckResponse, NoExtension, StringValue};
 use crate::request::{Command, Transaction};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 impl<'a> Transaction<NoExtension> for DomainCheck<'a> {}
 
 impl<'a> Command for DomainCheck<'a> {
-    type Response = DomainCheckResponse;
+    type Response = CheckResponse;
     const COMMAND: &'static str = "check";
 }
 
@@ -44,34 +44,6 @@ pub struct DomainCheck<'a> {
     list: DomainList<'a>,
 }
 
-// Response
-
-/// Type that represents the &lt;cd&gt; tag for domain check response
-#[derive(Deserialize, Debug)]
-pub struct DomainCheckResponseDataItem {
-    /// Data under the &lt;name&gt; tag
-    #[serde(rename = "name")]
-    pub domain: Available,
-    /// The reason for (un)availability
-    pub reason: Option<StringValue<'static>>,
-}
-
-/// Type that represents the &lt;chkData&gt; tag for domain check response
-#[derive(Deserialize, Debug)]
-pub struct DomainCheckResponseData {
-    /// Data under the &lt;cd&gt; tag
-    #[serde(rename = "cd")]
-    pub domain_list: Vec<DomainCheckResponseDataItem>,
-}
-
-/// Type that represents the &lt;resData&gt; tag for domain check response
-#[derive(Deserialize, Debug)]
-pub struct DomainCheckResponse {
-    /// Data under the &lt;chkData&gt; tag
-    #[serde(rename = "chkData")]
-    pub check_data: DomainCheckResponseData,
-}
-
 #[cfg(test)]
 mod tests {
     use super::DomainCheck;
@@ -103,16 +75,10 @@ mod tests {
 
         assert_eq!(object.result.code, ResultCode::CommandCompletedSuccessfully);
         assert_eq!(object.result.message, SUCCESS_MSG.into());
-        assert_eq!(
-            result.check_data.domain_list[0].domain.name,
-            "eppdev.com".into()
-        );
-        assert!(result.check_data.domain_list[0].domain.available);
-        assert_eq!(
-            result.check_data.domain_list[1].domain.name,
-            "eppdev.net".into()
-        );
-        assert!(!result.check_data.domain_list[1].domain.available);
+        assert_eq!(result.check_data.list[0].resource.name, "eppdev.com".into());
+        assert!(result.check_data.list[0].resource.available);
+        assert_eq!(result.check_data.list[1].resource.name, "eppdev.net".into());
+        assert!(!result.check_data.list[1].resource.available);
         assert_eq!(object.tr_ids.client_tr_id.unwrap(), CLTRID.into());
         assert_eq!(object.tr_ids.server_tr_id, SVTRID.into());
     }

--- a/src/extensions/namestore.rs
+++ b/src/extensions/namestore.rs
@@ -106,7 +106,9 @@ mod tests {
 
         let namestore_ext = NameStore::new("com");
 
-        let object = DomainCheck::new(vec!["example1.com", "example2.com", "example3.com"]);
+        let object = DomainCheck {
+            domains: &["example1.com", "example2.com", "example3.com"],
+        };
 
         let serialized = <DomainCheck as Transaction<NameStore>>::serialize_request(
             &object,

--- a/src/host/check.rs
+++ b/src/host/check.rs
@@ -3,14 +3,14 @@
 use std::fmt::Debug;
 
 use super::XMLNS;
-use crate::common::{NoExtension, StringValue, Available};
+use crate::common::{CheckResponse, NoExtension, StringValue};
 use crate::request::{Command, Transaction};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 impl<'a> Transaction<NoExtension> for HostCheck<'a> {}
 
 impl<'a> Command for HostCheck<'a> {
-    type Response = HostCheckResponse;
+    type Response = CheckResponse;
     const COMMAND: &'static str = "check";
 }
 
@@ -48,34 +48,6 @@ pub struct HostCheck<'a> {
     list: HostList<'a>,
 }
 
-// Response
-
-/// Type that represents the &lt;cd&gt; tag for host check response
-#[derive(Deserialize, Debug)]
-pub struct HostCheckDataItem {
-    /// Data under the &lt;name&gt; tag
-    #[serde(rename = "name")]
-    pub host: Available,
-    /// The reason for (un)availability
-    pub reason: Option<StringValue<'static>>,
-}
-
-/// Type that represents the &lt;chkData&gt; tag for host check response
-#[derive(Deserialize, Debug)]
-pub struct HostCheckData {
-    /// Data under the &lt;cd&gt; tag
-    #[serde(rename = "cd")]
-    pub host_list: Vec<HostCheckDataItem>,
-}
-
-/// Type that represents the &lt;resData&gt; tag for host check response
-#[derive(Deserialize, Debug)]
-pub struct HostCheckResponse {
-    /// Data under the &lt;chkData&gt; tag
-    #[serde(rename = "chkData")]
-    pub check_data: HostCheckData,
-}
-
 #[cfg(test)]
 mod tests {
     use super::HostCheck;
@@ -108,15 +80,15 @@ mod tests {
         assert_eq!(object.result.code, ResultCode::CommandCompletedSuccessfully);
         assert_eq!(object.result.message, SUCCESS_MSG.into());
         assert_eq!(
-            result.check_data.host_list[0].host.name,
+            result.check_data.list[0].resource.name,
             "host1.eppdev-1.com".into()
         );
-        assert!(result.check_data.host_list[0].host.available);
+        assert!(result.check_data.list[0].resource.available);
         assert_eq!(
-            result.check_data.host_list[1].host.name,
+            result.check_data.list[1].resource.name,
             "ns1.testing.com".into()
         );
-        assert!(!result.check_data.host_list[1].host.available);
+        assert!(!result.check_data.list[1].resource.available);
         assert_eq!(object.tr_ids.client_tr_id.unwrap(), CLTRID.into());
         assert_eq!(object.tr_ids.server_tr_id, SVTRID.into());
     }

--- a/src/host/check.rs
+++ b/src/host/check.rs
@@ -80,12 +80,12 @@ mod tests {
         assert_eq!(object.result.code, ResultCode::CommandCompletedSuccessfully);
         assert_eq!(object.result.message, SUCCESS_MSG.into());
         assert_eq!(
-            result.check_data.list[0].resource.name,
+            result.check_data.list[0].resource.id,
             "host1.eppdev-1.com".into()
         );
         assert!(result.check_data.list[0].resource.available);
         assert_eq!(
-            result.check_data.list[1].resource.name,
+            result.check_data.list[1].resource.id,
             "ns1.testing.com".into()
         );
         assert!(!result.check_data.list[1].resource.available);

--- a/src/host/check.rs
+++ b/src/host/check.rs
@@ -58,7 +58,7 @@ pub struct HostAvailable {
     pub name: StringValue<'static>,
     /// The host (un)availability
     #[serde(rename = "avail")]
-    pub available: u16,
+    pub available: bool,
 }
 
 /// Type that represents the &lt;cd&gt; tag for host check response
@@ -122,12 +122,12 @@ mod tests {
             result.check_data.host_list[0].host.name,
             "host1.eppdev-1.com".into()
         );
-        assert_eq!(result.check_data.host_list[0].host.available, 1);
+        assert!(result.check_data.host_list[0].host.available);
         assert_eq!(
             result.check_data.host_list[1].host.name,
             "ns1.testing.com".into()
         );
-        assert_eq!(result.check_data.host_list[1].host.available, 0);
+        assert!(!result.check_data.host_list[1].host.available);
         assert_eq!(object.tr_ids.client_tr_id.unwrap(), CLTRID.into());
         assert_eq!(object.tr_ids.server_tr_id, SVTRID.into());
     }

--- a/src/host/check.rs
+++ b/src/host/check.rs
@@ -79,16 +79,10 @@ mod tests {
 
         assert_eq!(object.result.code, ResultCode::CommandCompletedSuccessfully);
         assert_eq!(object.result.message, SUCCESS_MSG.into());
-        assert_eq!(
-            result.check_data.list[0].resource.id,
-            "host1.eppdev-1.com".into()
-        );
-        assert!(result.check_data.list[0].resource.available);
-        assert_eq!(
-            result.check_data.list[1].resource.id,
-            "ns1.testing.com".into()
-        );
-        assert!(!result.check_data.list[1].resource.available);
+        assert_eq!(result.list[0].id, "host1.eppdev-1.com");
+        assert!(result.list[0].available);
+        assert_eq!(result.list[1].id, "ns1.testing.com");
+        assert!(!result.list[1].available);
         assert_eq!(object.tr_ids.client_tr_id.unwrap(), CLTRID.into());
         assert_eq!(object.tr_ids.server_tr_id, SVTRID.into());
     }

--- a/src/host/check.rs
+++ b/src/host/check.rs
@@ -3,7 +3,7 @@
 use std::fmt::Debug;
 
 use super::XMLNS;
-use crate::common::{NoExtension, StringValue};
+use crate::common::{NoExtension, StringValue, Available};
 use crate::request::{Command, Transaction};
 use serde::{Deserialize, Serialize};
 
@@ -50,23 +50,12 @@ pub struct HostCheck<'a> {
 
 // Response
 
-/// Type that represents the &lt;name&gt; tag for host check response
-#[derive(Deserialize, Debug)]
-pub struct HostAvailable {
-    /// The host name
-    #[serde(rename = "$value")]
-    pub name: StringValue<'static>,
-    /// The host (un)availability
-    #[serde(rename = "avail")]
-    pub available: bool,
-}
-
 /// Type that represents the &lt;cd&gt; tag for host check response
 #[derive(Deserialize, Debug)]
 pub struct HostCheckDataItem {
     /// Data under the &lt;name&gt; tag
     #[serde(rename = "name")]
-    pub host: HostAvailable,
+    pub host: Available,
     /// The reason for (un)availability
     pub reason: Option<StringValue<'static>>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,9 @@
 //! let response = client.transact(&domain_check, "transaction-id").await.unwrap();
 //!
 //! // print the availability results
-//! response.res_data.unwrap().check_data.list
+//! response.res_data.unwrap().list
 //!     .iter()
-//!     .for_each(|chk| println!("Domain: {}, Available: {}", chk.resource.id, chk.resource.available));
+//!     .for_each(|chk| println!("Domain: {}, Available: {}", chk.id, chk.available));
 //!
 //! // Close the connection
 //! client.transact(&Logout, "transaction-id").await.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,9 +64,9 @@
 //!
 //! // Make a domain check call, which returns an object of type EppDomainCheckResponse
 //! // that contains the result of the call
-//! let domain_check = DomainCheck::new(
-//!     vec!["eppdev.com", "eppdev.net"],
-//! );
+//! let domain_check = DomainCheck {
+//!     domains: &["eppdev.com", "eppdev.net"],
+//! };
 //!
 //! let response = client.transact(&domain_check, "transaction-id").await.unwrap();
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,9 @@
 //! let response = client.transact(&domain_check, "transaction-id").await.unwrap();
 //!
 //! // print the availability results
-//! response.res_data.unwrap().check_data.domain_list
+//! response.res_data.unwrap().check_data.list
 //!     .iter()
-//!     .for_each(|chk| println!("Domain: {}, Available: {}", chk.domain.name, chk.domain.available));
+//!     .for_each(|chk| println!("Domain: {}, Available: {}", chk.resource.name, chk.resource.available));
 //!
 //! // Close the connection
 //! client.transact(&Logout, "transaction-id").await.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@
 //! // print the availability results
 //! response.res_data.unwrap().check_data.list
 //!     .iter()
-//!     .for_each(|chk| println!("Domain: {}, Available: {}", chk.resource.name, chk.resource.available));
+//!     .for_each(|chk| println!("Domain: {}, Available: {}", chk.resource.id, chk.resource.available));
 //!
 //! // Close the connection
 //! client.transact(&Logout, "transaction-id").await.unwrap();

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -107,5 +107,5 @@ async fn client() {
     assert_eq!(rsp.result.code, ResultCode::CommandCompletedSuccessfully);
 
     let result = rsp.res_data().unwrap();
-    assert_eq!(result.check_data.list[0].resource.id, "eppdev.com".into());
+    assert_eq!(result.list[0].id, "eppdev.com");
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -101,7 +101,12 @@ async fn client() {
         .unwrap();
 
     let rsp = client
-        .transact(&DomainCheck::new(vec!["eppdev.com", "eppdev.net"]), CLTRID)
+        .transact(
+            &DomainCheck {
+                domains: &["eppdev.com", "eppdev.net"],
+            },
+            CLTRID,
+        )
         .await
         .unwrap();
     assert_eq!(rsp.result.code, ResultCode::CommandCompletedSuccessfully);

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -107,8 +107,5 @@ async fn client() {
     assert_eq!(rsp.result.code, ResultCode::CommandCompletedSuccessfully);
 
     let result = rsp.res_data().unwrap();
-    assert_eq!(
-        result.check_data.domain_list[0].domain.name,
-        "eppdev.com".into()
-    );
+    assert_eq!(result.check_data.list[0].resource.name, "eppdev.com".into());
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -107,5 +107,5 @@ async fn client() {
     assert_eq!(rsp.result.code, ResultCode::CommandCompletedSuccessfully);
 
     let result = rsp.res_data().unwrap();
-    assert_eq!(result.check_data.list[0].resource.name, "eppdev.com".into());
+    assert_eq!(result.check_data.list[0].resource.id, "eppdev.com".into());
 }


### PR DESCRIPTION
I noticed that the `CheckResponse` types for contact/domain/host were nearly identical, so I tried to deduplicate them. Then I also figured out a way to intermediate the deserialized type such that the public interface is quite a bit more idiomatic (less nesting, simple `String` type instead of `StringValue`), both for command and response types.

If this seems like an improvement we could probably do the rest of the API too, so that we have many fewer duplicate types and can also present a more ergonomic public API.