### PR TITLE
Improve robustness against dropping futures

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -109,7 +109,7 @@ impl<C: Connector> EppClient<C> {
     pub async fn hello(&mut self) -> Result<Greeting, Error> {
         let hello_xml = HelloDocument::default().serialize()?;
 
-        let response = self.connection.transact(&hello_xml).await?;
+        let response = self.connection.transact(&hello_xml)?.await?;
 
         Ok(GreetingDocument::deserialize(&response)?.data)
     }
@@ -127,7 +127,7 @@ impl<C: Connector> EppClient<C> {
         let epp_xml =
             <Cmd as Transaction<Ext>>::serialize_request(data.command, data.extension, id)?;
 
-        let response = self.connection.transact(&epp_xml).await?;
+        let response = self.connection.transact(&epp_xml)?.await?;
 
         match Cmd::deserialize_response(&response) {
             Ok(response) => Ok(response),
@@ -141,7 +141,7 @@ impl<C: Connector> EppClient<C> {
     /// Accepts raw EPP XML and returns the raw EPP XML response to it.
     /// Not recommended for direct use but sometimes can be useful for debugging
     pub async fn transact_xml(&mut self, xml: &str) -> Result<String, Error> {
-        self.connection.transact(xml).await
+        self.connection.transact(xml)?.await
     }
 
     /// Returns the greeting received on establishment of the connection in raw xml form

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -96,6 +96,7 @@ impl<C: Connector> EppConnection<C> {
     }
 
     pub(crate) async fn reconnect(&mut self) -> Result<(), Error> {
+        debug!("{}: reconnecting", self.registry);
         self.ready = false;
         self.stream = self.connector.connect(self.timeout).await?;
         self.greeting = self.get_epp_response().await?;
@@ -107,6 +108,7 @@ impl<C: Connector> EppConnection<C> {
     /// receieved to the request
     pub(crate) async fn transact(&mut self, content: &str) -> Result<String, Error> {
         if !self.ready {
+            debug!("{}: connection not ready", self.registry);
             self.reconnect().await?;
         }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -15,7 +15,7 @@ use crate::error::Error;
 
 /// EPP Connection struct with some metadata for the connection
 pub(crate) struct EppConnection<C: Connector> {
-    registry: String,
+    pub registry: String,
     connector: C,
     stream: C::Connection,
     pub greeting: String,
@@ -74,7 +74,6 @@ impl<C: Connector> EppConnection<C> {
 
     /// Sends an EPP XML request to the registry and returns the response
     pub(crate) fn transact<'a>(&'a mut self, command: &str) -> Result<RequestFuture<'a, C>, Error> {
-        debug!("{}: request: {}", self.registry, command);
         let new = RequestState::new(command)?;
 
         // If we have a request currently in flight, finish that first

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types to wrap internal errors and make EPP errors easier to read
 
+use std::array::TryFromSliceError;
 use std::error::Error as StdError;
 use std::fmt::{self, Display};
 use std::io;
@@ -67,6 +68,12 @@ impl From<FromUtf8Error> for Error {
 
 impl From<Utf8Error> for Error {
     fn from(e: Utf8Error) -> Self {
+        Self::Other(e.into())
+    }
+}
+
+impl From<TryFromSliceError> for Error {
+    fn from(e: TryFromSliceError) -> Self {
         Self::Other(e.into())
     }
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -103,7 +103,7 @@ async fn client() {
         .unwrap();
 
     assert_eq!(client.xml_greeting(), xml("response/greeting.xml"));
-    client
+    let rsp = client
         .transact(
             &Login::new(
                 "username",
@@ -114,6 +114,8 @@ async fn client() {
         )
         .await
         .unwrap();
+
+    assert_eq!(rsp.result.code, ResultCode::CommandCompletedSuccessfully);
 
     let rsp = client
         .transact(


### PR DESCRIPTION
While #81 tried to improve the situation with a simple binary state, it turned out not to work. For one, it didn't correctly set the `ready` flag to false when starting to send a request. For another, it implicitly reconnected, which doesn't work because we rely on the caller to authenticate.

Here, I bit the bullet and wrote a manual `Future` implementation. The idea here is that we keep in track of any in-flight requests in the `EppConnection`. Any request that is in progress must then be finished before we start a new one.