### PR TITLE
Change MessageAck message_id to be a &str

### DIFF
--- a/src/message/ack.rs
+++ b/src/message/ack.rs
@@ -19,14 +19,14 @@ pub struct MessageAck<'a> {
     op: &'a str,
     /// The ID of the message to be acknowledged
     #[serde(rename = "msgID")]
-    message_id: String,
+    message_id: &'a str,
 }
 
 impl<'a> MessageAck<'a> {
-    pub fn new(message_id: u32) -> Self {
+    pub fn new(message_id: &'a str) -> Self {
         Self {
             op: "ack",
-            message_id: message_id.to_string(),
+            message_id,
         }
     }
 }
@@ -39,7 +39,7 @@ mod tests {
 
     #[test]
     fn command() {
-        let object = MessageAck::new(12345);
+        let object = MessageAck::new("12345");
         assert_serialized("request/message/ack.xml", &object);
     }
 


### PR DESCRIPTION
While all the examples in RFC 5730 use numbers, there is nothing
normative in section 2.9.2.3 that constrains msgID to be a number.
And if we look at the XML Schema, we find that msgID is defined
to be of type `token`, which seems to be defined as a string
that does not contain line feeds, carriage returns, tabs, leading
or trailing spaces or multiple spaces.

While we might define a more specific token type in the future,
for now sticking with just &str seems reasonable and this also
matches the type for `MessageQueue::id`.