### PR TITLE
Allow changing passwords upon login

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@
 //!         Err(e) => panic!("Failed to create EppClient: {}",  e)
 //!     };
 //!
-//!     let login = Login::new("username", "password", None);
+//!     let login = Login::new("username", "password", None, None);
 //!     client.transact(&login, "transaction-id").await.unwrap();
 //!
 //!     // Execute an EPP Command against the registry with distinct request and response objects

--- a/src/login.rs
+++ b/src/login.rs
@@ -19,6 +19,9 @@ pub struct Login<'a> {
     /// The password to use for the login
     #[serde(rename = "pw", default)]
     password: StringValue<'a>,
+    /// A new password which should be set
+    #[serde(rename = "newPW", default, skip_serializing_if = "Option::is_none")]
+    new_password: Option<StringValue<'a>>,
     /// Data under the <options> tag
     options: Options<'a>,
     /// Data under the <svcs> tag
@@ -27,12 +30,13 @@ pub struct Login<'a> {
 }
 
 impl<'a> Login<'a> {
-    pub fn new(username: &'a str, password: &'a str, ext_uris: Option<&'_ [&'a str]>) -> Self {
+    pub fn new(username: &'a str, password: &'a str, new_password: Option<&'a str>, ext_uris: Option<&'_ [&'a str]>) -> Self {
         let ext_uris = ext_uris.map(|uris| uris.iter().map(|&u| u.into()).collect());
 
         Self {
             username: username.into(),
             password: password.into(),
+            new_password: new_password.map(Into::into),
             options: Options {
                 version: EPP_VERSION.into(),
                 lang: EPP_LANG.into(),
@@ -73,7 +77,7 @@ mod tests {
     #[test]
     fn command() {
         let ext_uris = Some(&["http://schema.ispapi.net/epp/xml/keyvalue-1.0"][..]);
-        let object = Login::new("username", "password", ext_uris);
+        let object = Login::new("username", "password", Some("new-password"), ext_uris);
         assert_serialized("request/login.xml", &object);
     }
 

--- a/src/login.rs
+++ b/src/login.rs
@@ -30,7 +30,12 @@ pub struct Login<'a> {
 }
 
 impl<'a> Login<'a> {
-    pub fn new(username: &'a str, password: &'a str, new_password: Option<&'a str>, ext_uris: Option<&'_ [&'a str]>) -> Self {
+    pub fn new(
+        username: &'a str,
+        password: &'a str,
+        new_password: Option<&'a str>,
+        ext_uris: Option<&'_ [&'a str]>,
+    ) -> Self {
         let ext_uris = ext_uris.map(|uris| uris.iter().map(|&u| u.into()).collect());
 
         Self {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -109,6 +109,7 @@ async fn client() {
             &Login::new(
                 "username",
                 "password",
+                None,
                 Some(&["http://schema.ispapi.net/epp/xml/keyvalue-1.0"]),
             ),
             CLTRID,
@@ -184,6 +185,7 @@ async fn dropped() {
             &Login::new(
                 "username",
                 "password",
+                None,
                 Some(&["http://schema.ispapi.net/epp/xml/keyvalue-1.0"]),
             ),
             CLTRID,

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -109,7 +109,7 @@ async fn client() {
             &Login::new(
                 "username",
                 "password",
-                None,
+                Some("new-password"),
                 Some(&["http://schema.ispapi.net/epp/xml/keyvalue-1.0"]),
             ),
             CLTRID,
@@ -185,7 +185,7 @@ async fn dropped() {
             &Login::new(
                 "username",
                 "password",
-                None,
+                Some("new-password"),
                 Some(&["http://schema.ispapi.net/epp/xml/keyvalue-1.0"]),
             ),
             CLTRID,

--- a/tests/resources/request/login.xml
+++ b/tests/resources/request/login.xml
@@ -4,6 +4,7 @@
         <login>
             <clID>username</clID>
             <pw>password</pw>
+            <newPW>new-password</newPW>
             <options>
                 <version>1.0</version>
                 <lang>en</lang>


### PR DESCRIPTION
Adds field `new_passport` to login payload. [RFC 5730](https://www.ietf.org/rfc/rfc5730.txt) specifies:

```
   In addition to the standard EPP command elements, the <login> command
   contains the following child elements: [...]

   -  An OPTIONAL <newPW> element that contains a new plain text
      password to be assigned to the client for use with subsequent
      <login> commands.  The value of this element is case sensitive.
```