### PR TITLE
add consts for common periods

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -138,10 +138,10 @@ impl<C: Connector> EppClient<C> {
             return Ok(rsp.data);
         }
 
-        let err = crate::error::Error::Command(ResponseStatus {
+        let err = crate::error::Error::Command(Box::new(ResponseStatus {
             result: rsp.data.result,
             tr_ids: rsp.data.tr_ids,
-        });
+        }));
 
         error!(%response, "Failed to deserialize response for transaction: {}", err);
         Err(err)

--- a/src/common.rs
+++ b/src/common.rs
@@ -12,7 +12,7 @@ pub(crate) const EPP_XMLNS: &str = "urn:ietf:params:xml:ns:epp-1.0";
 
 /// Wraps String for easier serialization to and from values that are inner text
 /// for tags rather than attributes
-#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Default, Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct StringValue<'a>(Cow<'a, str>);
 
 impl Deref for StringValue<'_> {
@@ -47,7 +47,7 @@ impl From<String> for StringValue<'static> {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 /// An empty placeholder tag. To be refactored to something more compliant later.
 pub struct NoExtension;
 
@@ -123,7 +123,7 @@ impl From<DeserializedCheckResponse> for CheckResponse {
 }
 
 /// The <option> type in EPP XML login requests
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 #[serde(rename = "options")]
 pub struct Options<'a> {
     /// The EPP version being used
@@ -143,7 +143,7 @@ impl<'a> Options<'a> {
 }
 
 /// The <svcExtension> type in EPP XML
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 #[serde(rename = "svcExtension")]
 pub struct ServiceExtension<'a> {
     /// The service extension URIs being represented by <extURI> in EPP XML
@@ -152,7 +152,7 @@ pub struct ServiceExtension<'a> {
 }
 
 /// The <svcs> type in EPP XML
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct Services<'a> {
     /// The service URIs being used by this EPP session represented by <objURI> in EPP XML
     #[serde(rename = "objURI")]

--- a/src/contact/info.rs
+++ b/src/contact/info.rs
@@ -171,7 +171,7 @@ mod tests {
             result.info_data.updated_at,
             Utc.with_ymd_and_hms(2021, 7, 23, 13, 9, 9).single()
         );
-        assert_eq!((*auth_info).password, "eppdev-387323".into());
+        assert_eq!(auth_info.password, "eppdev-387323".into());
         assert_eq!(object.tr_ids.client_tr_id.unwrap(), CLTRID.into());
         assert_eq!(object.tr_ids.server_tr_id, SVTRID.into());
     }

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -132,6 +132,31 @@ impl Period {
     }
 }
 
+pub const ONE_YEAR: Period = Period {
+    unit: 'y',
+    length: 1,
+};
+
+pub const TWO_YEARS: Period = Period {
+    unit: 'y',
+    length: 2,
+};
+
+pub const THREE_YEARS: Period = Period {
+    unit: 'y',
+    length: 3,
+};
+
+pub const ONE_MONTH: Period = Period {
+    unit: 'm',
+    length: 1,
+};
+
+pub const SIX_MONTHS: Period = Period {
+    unit: 'm',
+    length: 6,
+};
+
 /// The &lt;authInfo&gt; tag for domain and contact transactions
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DomainAuthInfo<'a> {

--- a/src/domain/info.rs
+++ b/src/domain/info.rs
@@ -150,7 +150,7 @@ mod tests {
         let result = object.res_data().unwrap();
         let auth_info = result.info_data.auth_info.as_ref().unwrap();
         let ns_list = result.info_data.ns.as_ref().unwrap();
-        let ns = (*ns_list).host_obj.as_ref().unwrap();
+        let ns = ns_list.host_obj.as_ref().unwrap();
         let hosts = result.info_data.hosts.as_ref().unwrap();
         let statuses = result.info_data.statuses.as_ref().unwrap();
         let registrant = result.info_data.registrant.as_ref().unwrap();
@@ -194,7 +194,7 @@ mod tests {
             *result.info_data.expiring_at.as_ref().unwrap(),
             Utc.with_ymd_and_hms(2023, 7, 23, 15, 31, 20).unwrap()
         );
-        assert_eq!((*auth_info).password, "epP4uthd#v".into());
+        assert_eq!(auth_info.password, "epP4uthd#v".into());
         assert_eq!(object.tr_ids.client_tr_id.unwrap(), CLTRID.into());
         assert_eq!(object.tr_ids.server_tr_id, SVTRID.into());
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,7 @@ use crate::response::ResponseStatus;
 /// Error enum holding the possible error types
 #[derive(Debug)]
 pub enum Error {
-    Command(ResponseStatus),
+    Command(Box<ResponseStatus>),
     Io(std::io::Error),
     Timeout,
     Xml(Box<dyn StdError + Send + Sync>),

--- a/src/extensions/consolidate.rs
+++ b/src/extensions/consolidate.rs
@@ -25,7 +25,7 @@ impl Extension for UpdateWithNameStore<'_> {
     type Response = NameStore<'static>;
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct GMonthDay {
     pub month: u8,
     pub day: u8,

--- a/src/hello.rs
+++ b/src/hello.rs
@@ -29,7 +29,7 @@ impl Default for HelloDocument {
 // Response
 
 /// Type for data within the <svcMenu> section of an EPP greeting
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ServiceMenu {
     pub options: Options<'static>,
     pub services: Services<'static>,
@@ -70,31 +70,31 @@ impl<'a, 'de: 'a> Deserialize<'de> for ServiceMenu {
 }
 
 /// Type corresponding to <all> in the EPP greeting XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct All;
 
 /// Type corresponding to <none> in the EPP greeting XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct NoAccess;
 
 /// Type corresponding to <null> in the EPP greeting XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct Null;
 
 /// Type corresponding to <personal> in the EPP greeting XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct Personal;
 
 /// Type corresponding to <personalAndOther> in the EPP greeting XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct PersonalAndOther;
 
 /// Type corresponding to <other> in the EPP greeting XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct Other;
 
 /// Type corresponding to possible <retention> type values
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub enum AccessType {
     /// Data for the <all> tag
     #[serde(rename = "all")]
@@ -117,14 +117,14 @@ pub enum AccessType {
 }
 
 /// Type corresponding to <access> in the EPP greeting XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct Access {
     #[serde(flatten)]
     pub ty: AccessType,
 }
 
 /// Type corresponding to possible <purpose> type values
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub enum PurposeType {
     /// Data for the <admin> tag
     #[serde(rename = "admin")]
@@ -141,14 +141,14 @@ pub enum PurposeType {
 }
 
 /// Type corresponding to <purpose> in the EPP greeting XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct Purpose {
     #[serde(rename = "$value")]
     pub purpose: Vec<PurposeType>,
 }
 
 /// Type corresponding to possible <purpose> type values
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub enum RecipientType {
     /// Data for the <other> tag
     #[serde(rename = "other")]
@@ -168,34 +168,34 @@ pub enum RecipientType {
 }
 
 /// Type corresponding to <recipeint> in the EPP greeting XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct Recipient {
     #[serde(rename = "$value")]
     pub recipient: Vec<RecipientType>,
 }
 
 /// Type corresponding to <business> in the EPP greeting XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct Business;
 
 /// Type corresponding to <indefinite> in the EPP greeting XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct Indefinite;
 
 /// Type corresponding to <legal> in the EPP greeting XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct Legal;
 
 /// Type corresponding to <none> in the EPP greeting XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct No;
 
 /// Type corresponding to <stated> in the EPP greeting XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct Stated;
 
 /// Type corresponding to possible <retention> type values
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub enum RetentionType {
     /// Data for the <business> tag
     #[serde(rename = "business")]
@@ -215,14 +215,14 @@ pub enum RetentionType {
 }
 
 /// Type corresponding to <retention> in the EPP greeting XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct Retention {
     #[serde(flatten)]
     pub ty: RetentionType,
 }
 
 /// Type corresponding to <statement> in the EPP greeting XML (pending more compliant implementation)
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct Statement {
     /// Data for the <purpose> tag
     pub purpose: Purpose,
@@ -233,21 +233,21 @@ pub struct Statement {
 }
 
 /// Type corresponding to <absolute> value in the EPP greeting XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct Absolute {
     #[serde(rename = "$value")]
     pub absolute: StringValue<'static>,
 }
 
 /// Type corresponding to <relative> value in the EPP greeting XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct Relative {
     #[serde(rename = "$value")]
     pub relative: StringValue<'static>,
 }
 
 /// Type corresponding to possible <expiry> type values
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub enum ExpiryType {
     /// Data for the <absolute> tag
     #[serde(rename = "absolute")]
@@ -258,14 +258,14 @@ pub enum ExpiryType {
 }
 
 /// Type corresponding to <expiry> in the EPP greeting XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct Expiry {
     #[serde(flatten)]
     pub ty: ExpiryType,
 }
 
 /// Type corresponding to <dcp> in the EPP greeting XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct Dcp {
     /// Data for the <access> tag
     pub access: Access,
@@ -275,7 +275,7 @@ pub struct Dcp {
     pub expiry: Option<Expiry>,
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 /// Type corresponding to the <greeting> tag in the EPP greeting XML
 pub struct Greeting {
@@ -292,7 +292,7 @@ pub struct Greeting {
     pub dcp: Dcp,
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 #[serde(rename = "epp")]
 pub struct GreetingDocument {
     #[serde(rename = "greeting")]

--- a/src/login.rs
+++ b/src/login.rs
@@ -10,7 +10,7 @@ use crate::{
 
 impl<'a> Transaction<NoExtension> for Login<'a> {}
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug, Eq, PartialEq)]
 /// Type corresponding to the &lt;login&gt; tag in an EPP XML login request
 pub struct Login<'a> {
     /// The username to use for the login

--- a/src/logout.rs
+++ b/src/logout.rs
@@ -14,7 +14,7 @@ impl Command for Logout {
     const COMMAND: &'static str = "logout";
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 /// Type corresponding to the &lt;logout&gt; tag in an EPP XML logout request
 pub struct Logout;
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -8,11 +8,11 @@ use serde::Deserialize;
 use crate::common::StringValue;
 
 /// Type corresponding to the <undef> tag an EPP response XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct Undef;
 
 /// Type corresponding to the <value> tag under <extValue> in an EPP response XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct ResultValue {
     /// The XML namespace for the <value> tag
     #[serde(rename = "xmlns:epp")]
@@ -22,7 +22,7 @@ pub struct ResultValue {
 }
 
 /// Type corresponding to the <extValue> tag in an EPP response XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct ExtValue {
     /// Data under the <value> tag
     pub value: ResultValue,
@@ -31,7 +31,7 @@ pub struct ExtValue {
 }
 
 /// Type corresponding to the <result> tag in an EPP response XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct EppResult {
     /// The result code
     pub code: ResultCode,
@@ -44,7 +44,7 @@ pub struct EppResult {
 }
 
 /// Response codes as enumerated in section 3 of RFC 5730
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ResultCode {
     CommandCompletedSuccessfully = 1000,
     CommandCompletedSuccessfullyActionPending = 1001,
@@ -166,7 +166,7 @@ impl<'de> serde::de::Visitor<'de> for ResultCodeVisitor {
 }
 
 /// Type corresponding to the <trID> tag in an EPP response XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct ResponseTRID {
     /// The client TRID
     #[serde(rename = "clTRID")]
@@ -177,7 +177,7 @@ pub struct ResponseTRID {
 }
 
 /// Type corresponding to the <msgQ> tag in an EPP response XML
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct MessageQueue {
     /// The message count
     pub count: u32,
@@ -191,7 +191,7 @@ pub struct MessageQueue {
     pub message: Option<StringValue<'static>>,
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 /// Type corresponding to the &lt;response&gt; tag in an EPP response XML
 /// containing an &lt;extension&gt; tag
 pub struct Response<D, E> {
@@ -210,21 +210,21 @@ pub struct Response<D, E> {
     pub tr_ids: ResponseTRID,
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 #[serde(rename = "epp")]
 pub struct ResponseDocument<D, E> {
     #[serde(rename = "response")]
     pub data: Response<D, E>,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename = "epp")]
 pub struct ResultDocument {
     #[serde(rename = "response")]
     pub data: ResponseStatus,
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 /// Type corresponding to the &lt;response&gt; tag in an EPP response XML
 /// without <msgQ> or &lt;resData&gt; sections. Generally used for error handling
 pub struct ResponseStatus {


### PR DESCRIPTION
Currently when constructing a `Period`  you need to handle the Result at runtime. Checking for a valid period length when using fixed `Period`s adds unneeded boilerplate to application code.

This adds some common periods to avoid the boilerplate.